### PR TITLE
Take underscore out if there is one in snapshotname.

### DIFF
--- a/ZenPacks/zenoss/LinuxMonitor/SnapshotVolume.py
+++ b/ZenPacks/zenoss/LinuxMonitor/SnapshotVolume.py
@@ -39,8 +39,11 @@ class SnapshotVolume(schema.SnapshotVolume):
         # will generate its own UUID for the snapshot and passes it on to LVM,
         # and the snapshot in LVM will have a UUID attached to it in its name
 
-        # self.name(): snapshot-366fc7b1-4c11-4ae6-9ec2-d096df0194e0
-        return ['cinder.lvm:snapshotvolume|%s' % (self.name())]
+        # self.name(): _snapshot-366fc7b1-4c11-4ae6-9ec2-d096df0194e0
+        snapshotname = self.name()
+        if self.name().startswith('_'):
+            snapshotname = self.name()[1:]
+        return ['cinder.lvm:snapshotvolume|%s' % (snapshotname)]
 
     def index_object(self, idxs=None):
         super(SnapshotVolume, self).index_object(idxs=idxs)

--- a/ZenPacks/zenoss/LinuxMonitor/configure.zcml
+++ b/ZenPacks/zenoss/LinuxMonitor/configure.zcml
@@ -37,7 +37,7 @@
       <configure zcml:condition="have openstack_cinder_integration">
           <utility
               name="cinder.lvm"
-              factory=".openstack_cinder.CephCinderImplementationPlugin"
+              factory=".openstack_cinder.LinuxCinderImplementationPlugin"
               provides="ZenPacks.zenoss.OpenStackInfrastructure.interfaces.ICinderImplementationPlugin"
               />
       </configure>

--- a/ZenPacks/zenoss/LinuxMonitor/openstack_cinder.py
+++ b/ZenPacks/zenoss/LinuxMonitor/openstack_cinder.py
@@ -22,7 +22,7 @@ from ZenPacks.zenoss.OpenStackInfrastructure.cinder_integration \
     import BaseCinderImplementationPlugin
 
 
-class CephCinderImplementationPlugin(BaseCinderImplementationPlugin):
+class LinuxCinderImplementationPlugin(BaseCinderImplementationPlugin):
     implements(ICinderImplementationPlugin)
 
     def getVolumeIntegrationKeys(self, osi_volume):
@@ -37,9 +37,9 @@ class CephCinderImplementationPlugin(BaseCinderImplementationPlugin):
 
     @classmethod
     def reindex_implementation_components(cls, dmd):
-        results = ICatalogTool(dmd.devices).search(
-            ('ZenPacks.zenoss.LinuxMonitor.LinuxVolume.LinuxVolume',
-             'ZenPacks.zenoss.LinuxMonitor.LinuxVolume.LinuxVolume',)
+        results = ICatalogTool(dmd).search(
+            ('ZenPacks.zenoss.LinuxMonitor.LogicalVolume.LogicalVolume',
+             'ZenPacks.zenoss.LinuxMonitor.SnapshotVolume.SnapshotVolume',)
         )
 
         for brain in results:


### PR DESCRIPTION
ZEN-22158

* change class name CephCinderImplementationPlugin
  to to LinuxCinderImplementationPlugin
* fixed class names in class LinuxCinderImplementationPlugin,
  method reindex_implementation_components()