### PR TITLE
Fix LVM modeling IndexError on long lsblk lines.

### DIFF
--- a/ZenPacks/zenoss/LinuxMonitor/modeler/plugins/zenoss/cmd/linux/lvm.py
+++ b/ZenPacks/zenoss/LinuxMonitor/modeler/plugins/zenoss/cmd/linux/lvm.py
@@ -82,7 +82,7 @@ class lvm(CommandPlugin):
     MAJ:MIN can be used for diskstats
     """
 
-    command = ('lsblk -lb 2>&1; '
+    command = ('lsblk -rb 2>&1; '
                'sudo pvs --units b --nosuffix -o pv_name,pv_fmt,pv_attr,pv_size,pv_free,pv_uuid,vg_name 2>&1; '
                'sudo vgs --units b --nosuffix -o vg_name,vg_attr,vg_size,vg_free,vg_uuid 2>&1; '
                'sudo lvs --units b --nosuffix -o lv_name,vg_name,lv_attr,lv_size,lv_uuid,origin 2>&1 ')


### PR DESCRIPTION
The cmd.linux.lvm modeler plugin was running "lsblk -lb" to capture
information about all block devices. Block devices with very long names
like the following created by docker thin pool usage result in each
block device entry being split into two lines. Using "lsblk -rb" to use
raw instead of list formatting fixes it.

Fixes ZEN-22253.