### PR TITLE
Fix "Component Graphs" for custom getGraphObjects

### DIFF
--- a/ZenPacks/zenoss/LinuxMonitor/__init__.py
+++ b/ZenPacks/zenoss/LinuxMonitor/__init__.py
@@ -17,3 +17,6 @@ if os.path.isdir(skinsDir):
 
 # CFG is necessary when using zenpacklib.TestCase.
 CFG = zenpacklib.load_yaml()
+
+# Patch last to avoid import recursion problems.
+from ZenPacks.zenoss.LinuxMonitor import patches  # NOQA

--- a/ZenPacks/zenoss/LinuxMonitor/patches/__init__.py
+++ b/ZenPacks/zenoss/LinuxMonitor/patches/__init__.py
@@ -1,0 +1,30 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2014-2016, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+import logging
+from importlib import import_module
+LOG = logging.getLogger('zen.LinuxMonitor')
+
+
+def optional_import(module_name, patch_module_name):
+    """Import patch_module_name only if module_name is importable."""
+    try:
+        import_module(module_name)
+    except ImportError:
+        pass
+    else:
+        try:
+            import_module(
+                '.{0}'.format(patch_module_name),
+                'ZenPacks.zenoss.LinuxMonitor.patches')
+        except ImportError:
+            LOG.exception("failed to apply %s patches", patch_module_name)
+
+
+optional_import('Products.ZenModel', 'platform')

--- a/ZenPacks/zenoss/LinuxMonitor/patches/platform.py
+++ b/ZenPacks/zenoss/LinuxMonitor/patches/platform.py
@@ -1,0 +1,53 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2016, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+import collections
+
+from Products.ZenUtils.Utils import getObjectsFromCatalog, monkeypatch
+from Products.Zuul.facades.devicefacade import DeviceFacade
+
+from ZenPacks.zenoss.LinuxMonitor.LinuxDevice import LinuxDevice
+
+
+if hasattr(DeviceFacade, "getGraphDefinitionsForComponent"):
+    @monkeypatch(DeviceFacade)
+    def getGraphDefinitionsForComponent(self, *args, **kwargs):
+        """Return dictionary of meta_type to associated graph definitions.
+
+        component.getGraphObjects() can return pairs of (graphDef, context)
+        where context is not the component. One example is
+        FileSystem.getGraphObjects returning pairs for graphs on its underlying
+        HardDisk. We have to make sure to return these graph definitions under
+        their meta_type, not component's meta_type.
+
+        We accept *args and **kwargs to be less brittle in case the
+        monkeypatched method changes signature in an otherwise unaffecting way.
+
+        args is expected to look something like this:
+
+            ('/zport/dmd/Devices/Server/SSH/Linux/devices/centos-7',)
+
+        kwargs is expected to look like this:
+
+            {}
+
+        """
+        obj = self._getObject(args[0])
+
+        # Limit the patch scope to this ZenPack even though it'd probably be a
+        # good idea for everything.
+        if not isinstance(obj, LinuxDevice):
+            return original(self, *args, **kwargs)  # NOQA
+
+        graphDefs = collections.defaultdict(set)
+        for component in getObjectsFromCatalog(obj.componentSearch):
+            for graphDef, context in component.getGraphObjects():
+                graphDefs[context.meta_type].add(graphDef.id)
+
+        return graphDefs


### PR DESCRIPTION
This ZenPack makes heavy use of overridding component.getGraphObjects()
to show useful graphs from related contexts for many component types.
Currently this isn't well-supported by the platform. All of the
other-contexted graph definitions will appear as choices in the graph
selection when the component type is selected. If any of these
other-contexted graphs are chosen, no data will be displayed on the
graphs.

This monkeypatch fixes the platform to filter out other-contexted graph
definitions, but only for Linux devices.

Fixes ZEN-22254.