### PR TITLE
Fix lvsstatus parser now that LV ids are prefixed

### DIFF
--- a/ZenPacks/zenoss/LinuxMonitor/parsers/linux/lvsstatus.py
+++ b/ZenPacks/zenoss/LinuxMonitor/parsers/linux/lvsstatus.py
@@ -1,105 +1,130 @@
 ##############################################################################
 #
-# Copyright (C) Zenoss, Inc. 2008, all rights reserved.
+# Copyright (C) Zenoss, Inc. 2016, all rights reserved.
 #
 # This content is made available according to terms specified in
 # License.zenoss under the directory where your Zenoss product is installed.
 #
 ##############################################################################
 
+"""Parse results of lvm2 "lvs" command.
 
-import re
+We'll only look at state and health for now, but if we need any of the
+following in the future, we only need to add the datapoint and handler.
 
-from Products.ZenRRD.CommandParser import CommandParser
-from ZenPacks.zenoss.LinuxMonitor.util import LVMAttributeParser
-from Products.ZenUtils.Utils import prepId
-
-'''
-We'll only look at state and health for now, but if we need any of the following in the future, 
-we only need to add the datapoint and handler
 # State: (a)ctive, (s)uspended, (I)nvalid snapshot, invalid (S)uspended snapshot,
         snapshot (m)erge failed, suspended snapshot (M)erge failed,
         mapped (d)evice present without tables, mapped device present with (i)nactive table
 # Volume Health: (p)artial, (r)efresh needed, (m)ismatches exist, (w)ritemostly, (X) unknown
 
-sample output:
-VG_LV Attr
-centos_root -wi-ao----
-centos_swap -wi-ao----
-fileserver_backup -wi-ao----
-fileserver_inactive -wi-------
-fileserver_media -wi-ao----
-fileserver_share owi-aos---
-fileserver_snap swi-a-s---
+CentOS 7 sample output:
 
-'''
+  centos         home                                           -wi-ao----
+  cinder-volumes _snapshot-9985dbc7-ff68-4cfd-b84d-6ce372afa3aa swi-a-s---
+  cinder-volumes volume-055e2dce-b50b-468b-af40-21b634a06280    -wi-a-----
+
+Ubuntu 14.04 sample output:
+
+  data docker     twi-i-tz-
+  data regularLV1 -wi-ao---
+  data serviced   twi-i-tz-
+
+"""
+
+from Products.ZenRRD.CommandParser import CommandParser
+from ZenPacks.zenoss.LinuxMonitor.util import LVMAttributeParser
+from Products.ZenUtils.Utils import prepId
 
 
 class lvsstatus(CommandParser):
 
-    scanner = r'(?P<component>\S+) *(?P<attributes>\S+)'
-
-    componentScanValue = 'id'
-
     lvm_parser = LVMAttributeParser()
 
     def dataForParser(self, context, dp):
-        # Borrowed from ComponentCommandParser
-        # This runs in the zenhub service, so it has access to the actual ZODB object
-        return dict(componentScanValue=getattr(context, self.componentScanValue))
+        """Add additional data to dp for the processResults method.
+
+        This method is executed in zenhub, so context will be a full
+        LogicalVolume or SnapshotVolume object.
+
+        """
+        return {
+            'vgname': getattr(context, 'vgname', None),
+            'lvname': getattr(context, 'title', None),
+            }
 
     def processResults(self, cmd, result):
-        lv_atts = {'type': 0, 'permissions': 1, 'allocation': 2, 'fixed': 3, 'state': 4, 'device': 5, 'type': 6, 'zeroes': 7, 'health': 8, 'skip': 9}
-        self._cmd = cmd
+        lv_atts = {
+            'type': 0,
+            'permissions': 1,
+            'allocation': 2,
+            'fixed': 3,
+            'state': 4,
+            'device': 5,
+            'type': 6,
+            'zeroes': 7,
+            'health': 8,
+            'skip': 9,
+            }
+
         for dp in cmd.points:
             if dp.id not in lv_atts:
                 continue
-            dp.component = dp.data['componentScanValue']
+
             for line in cmd.result.output.split('\n'):
-                match = re.search(self.scanner, line)
-                if not match or dp.component != match.groupdict()['component']:
+                try:
+                    vg_name, lv_name, lv_attr = line.strip().split()
+                except ValueError:
                     continue
-                value = 'None'
+
+                # Verify that this line is for the appropriate component.
+                if vg_name != dp.data['vgname'] or lv_name != dp.data['lvname']:
+                    continue
+
+                # Extract specific attribute value from lv_attr string.
+                av = lv_attr[lv_atts[dp.id]]
+
                 if dp.id == 'state':
-                    event, value = self.handleState(dp.component, match.groupdict()['attributes'][lv_atts[dp.id]])
+                    event, value = self.handleState(cmd, dp.component, av)
                 elif dp.id == 'health':
-                    event = self.handleHealth(dp.component, match.groupdict()['attributes'][lv_atts[dp.id]])
-                event['device'] = cmd.deviceConfig.name
-                event['component'] = prepId(dp.component)
-                event['eventClass'] = cmd.eventClass
-                result.events.append(event)
-                if value != 'None':
+                    event, value = self.handleHealth(cmd, dp.component, av)
+                else:
+                    # No handler for this attribute.
+                    continue
+
+                # Add default event fields to events returned by handler.
+                result.events.append(dict({
+                    'device': cmd.deviceConfig.name,
+                    'component': prepId(dp.component),
+                    'eventClass': cmd.eventClass,
+                    }, **event))
+
+                if value is not None:
                     result.values.append((dp, float(value)))
 
         return result
 
-    def handleState(self, component, attribute):
+    def handleState(self, cmd, component, attribute):
         if attribute == 'a':
-            summary = '{} in active state'.format(component)
-            severity = 0
-            value = 1
+            return ({
+                'summary': '{} in active state'.format(component),
+                'severity': 0,
+                }, 1)
         else:
-            reason = self.lvm_parser.lv_state(attribute)
-            if not reason:
-                reason = 'Inactive'
-            summary = '{} not active: {}'.format(component, reason)
-            severity = self._cmd.severity
-            value = 0
-        return ({
-            'summary': summary,
-            'severity': severity,
-        },
-            value)
+            reason = self.lvm_parser.lv_state(attribute) or 'Inactive'
+            return ({
+                'summary': '{} not active: {}'.format(component, reason),
+                'severity': cmd.severity,
+                }, 0)
 
-    def handleHealth(self, component, attribute):
+    def handleHealth(self, cmd, component, attribute):
         if attribute == '-':
-            summary = '{} healthy'.format(component)
-            severity = 0
+            return ({
+                'summary': '{} healthy'.format(component),
+                'severity': 0,
+                }, None)
         else:
             reason = self.lvm_parser.lv_health(attribute)
-            summary = '{} not healthy: {}'.format(component, reason)
-            severity = self._cmd.severity
-        return {
-            'summary': summary,
-            'severity': severity,
-        }
+            return ({
+                'summary': '{} not healthy: {}'.format(component, reason),
+                'severity': cmd.severity,
+                }, None)

--- a/ZenPacks/zenoss/LinuxMonitor/zenpack.yaml
+++ b/ZenPacks/zenoss/LinuxMonitor/zenpack.yaml
@@ -925,9 +925,10 @@ device_classes:
                 datasources:
                     status:
                         type: COMMAND
-                        commandTemplate: "/usr/bin/sudo /usr/sbin/lvs --noheadings -o vg_name,lv_name,lv_attr | /usr/bin/awk '{print $$1\"_\"$$2\" \"$$3}'"
                         usessh: true
+                        commandTemplate: "/usr/bin/env sudo lvs --noheadings -o vg_name,lv_name,lv_attr"
                         parser: ZenPacks.zenoss.LinuxMonitor.parsers.linux.lvsstatus
+                        component: "${here/id}"
                         eventClass: /Status
                         datapoints:
                             state:
@@ -940,9 +941,10 @@ device_classes:
                 datasources:
                     status:
                         type: COMMAND
-                        commandTemplate: "/usr/bin/sudo /usr/sbin/lvs --noheadings -o vg_name,lv_name,lv_attr | /usr/bin/awk '{print $$1\"_\"$$2\" \"$$3}'"
                         usessh: true
+                        commandTemplate: "/usr/bin/env sudo lvs --noheadings -o vg_name,lv_name,lv_attr"
                         parser: ZenPacks.zenoss.LinuxMonitor.parsers.linux.lvsstatus
+                        component: "${here/id}"
                         eventClass: /Status
                         datapoints:
                             state:


### PR DESCRIPTION
When the lvsstatus parser was written, LogicalVolume and SnapshotVolume
ids were just "<vgname_lvname>" which matched the output of the lvs
command being run for this parser. Now we're prefixing LV ids with "lv-"
so the match no longer works.

This change simplies the command being run by removing awk pre-parsing
and letting the lvsstatus parser do all the parsing work by specifically
matching the VG name and LV name in the output columns with the VG name
and LV name of each LogicalVolume and SnapshotVolume.

Fixes ZEN-22301.