### PR TITLE
Add Linux Server (SSH) device type on install

### DIFF
--- a/ZenPacks/zenoss/LinuxMonitor/__init__.py
+++ b/ZenPacks/zenoss/LinuxMonitor/__init__.py
@@ -7,6 +7,9 @@
 #
 ##############################################################################
 
+import logging
+LOG = logging.getLogger("zen.LinuxMonitor")
+
 from . import zenpacklib
 import os.path
 from Products.CMFCore.DirectoryView import registerDirectory
@@ -17,6 +20,35 @@ if os.path.isdir(skinsDir):
 
 # CFG is necessary when using zenpacklib.TestCase.
 CFG = zenpacklib.load_yaml()
+
+from . import schema
+
+
+class ZenPack(schema.ZenPack):
+
+    def install(self, app):
+        super(ZenPack, self).install(app)
+
+        self.register_devtype(
+            app.zport.dmd,
+            deviceclass="/Server/SSH/Linux",
+            description="Linux Server",
+            protocol="SSH")
+
+    def register_devtype(self, dmd, deviceclass, description, protocol):
+        try:
+            deviceclass = dmd.Devices.getOrganizer(deviceclass)
+
+            if (description, protocol) not in deviceclass.devtypes:
+                LOG.info(
+                    "registering %s (%s) device type",
+                    description,
+                    protocol)
+
+                deviceclass.register_devtype(description, protocol)
+        except Exception:
+            pass
+
 
 # Patch last to avoid import recursion problems.
 from ZenPacks.zenoss.LinuxMonitor import patches  # NOQA


### PR DESCRIPTION
Now that the /Server/SSH/Linux device class is owned by this ZenPack, it
must add the Linux Server (SSH) devtype. This devtype information is
used by the device add/discovery wizard to give users an easier to use
list of possible device types to add than the entire device class
hierarchy.

Fixes ZEN-22359.