### PR TITLE
Workaround "All on Same Graph?" issue for PV/VG

### DIFF
--- a/ZenPacks/zenoss/LinuxMonitor/zenpack.yaml
+++ b/ZenPacks/zenoss/LinuxMonitor/zenpack.yaml
@@ -962,16 +962,10 @@ device_classes:
                         maxy: 100
 
                         graphpoints:
-                            size:
-                                dpName: volume_size
-                                lineType: DONTDRAW
-                                legend: Total
-
-                            free:
+                            Used:
                                 dpName: volume_free
                                 lineType: AREA
-                                rpn: "size,-,size,/,-100,*"
-                                legend: Used
+                                rpn: "${here/pvsize},-,${here/pvsize},/,-100,*"
                                 format: "%7.2lf%%"
 
                 thresholds:
@@ -1041,20 +1035,16 @@ device_classes:
                         eventClass: /Status
 
                 graphs:
-                    Volume Group Utilization:
+                    Utilization:
                         units: percent
                         miny: 0
                         maxy: 100
 
                         graphpoints:
-                            size:
-                                dpName: group_size
-                                lineType: DONTDRAW
-
-                            free:
+                            Used:
                                 dpName: group_free
                                 lineType: AREA
-                                rpn: "size,-,size,/,-100,*"
+                                rpn: "${here/vgsize},-,${here/vgsize},/,-100,*"
                                 format: "%7.2lf%%"
 
             LogicalVolume:


### PR DESCRIPTION
There are a couple of issues (ZEN-22411 and ZEN-22413)  with Component
Graphs in Zenoss 5.1.1 that cause them not work when a graph point's RPN
refers to another graph point. We used this feature for PhysicalVolume
and VolumeGroup Utilization graphs.

To workaround the issue we use a TALES expression to get the current
size of the given PV/VG instead. This seems to work, but is not as good
in the long run because it doesn't accomodate for the size of the volume
changing over time as well.

Fixes ZEN-22254.