### PR TITLE
Revert status to be defined only by /Status/Ping

### DIFF
--- a/ZenPacks/zenoss/LinuxMonitor/LinuxDevice.py
+++ b/ZenPacks/zenoss/LinuxMonitor/LinuxDevice.py
@@ -54,29 +54,3 @@ class LinuxDevice(schema.LinuxDevice):
             if isinstance(fs, FileSystem):
                 if fs.impacting_object() == self:
                     yield fs
-
-    def status(self):
-        """Returns True if up, False if down.
-
-        The value returned by this method is used to determine the
-        "device status" shown in the top summary bar on the device screen.
-
-        What up and down means can be subjective. What we've decided for a
-        device monitored by default using SSH with periodic ping checks is that
-        it a device that is up has no critical events in the /Cmd/Fail or
-        /Status/Ping event classes.
-
-        """
-        if not self.monitorDevice():
-            return None
-
-        zep = getFacade("zep")
-        fltr = zep.createEventFilter(
-            element_identifier=self.id,
-            element_sub_identifier=("zencommand", ""),
-            event_class=("/Cmd/Fail", "/Status/Ping"),
-            severity=(SEVERITY_CRITICAL, SEVERITY_ERROR),
-            status=(STATUS_NEW, STATUS_ACKNOWLEDGED, STATUS_SUPPRESSED))
-
-        events = zep.getEventSummaries(0, limit=1, filter=fltr)
-        return events.get('total', 0) == 0

--- a/ZenPacks/zenoss/LinuxMonitor/zenpack.yaml
+++ b/ZenPacks/zenoss/LinuxMonitor/zenpack.yaml
@@ -8,13 +8,6 @@ classes:
         base: [zenpacklib.Device]
         label: Device
 
-        properties:
-            status:
-                label: Status
-                type: boolean
-                api_only: true
-                api_backendtype: method
-
         dynamicview_views: [service_view]
         dynamicview_relations:
             impacts:


### PR DESCRIPTION
The default definition of "status" in Zenoss is that the presence of
error or critical events in the /Status/Ping event class means down, and
the absence of such events means up.

A previous fix went in for ZEN-20498 to change the meaning of status for
/Server/SSH/Linux devices to continue using /Status/Ping to identify
down devices, but to also use /Cmd/Fail where zencommand creates events
cause by SSH failures. The idea was that if we're mostly monitoring a
device using SSH that the device is down if we can't. This turned out to
not be true at all. There are all sorts of /Cmd/Fail events generated by
zencommand that don't indicate the device is down. It could just be a
wrong username, or no username configured.

Since we don't have control over the events sent by zencommand when SSH
fails in various ways within this ZenPack, we can't change the meaning
of down to include those events in this ZenPack.

Unfixes ZEN-20498.