### PR TITLE
Explicitly label graphs for 4.X making labels uniq

### DIFF
--- a/ZenPacks/zenoss/LinuxMonitor/FileSystem.py
+++ b/ZenPacks/zenoss/LinuxMonitor/FileSystem.py
@@ -17,6 +17,7 @@ from Products.Zuul.form import schema
 from Products.Zuul.infos.component.filesystem import FileSystemInfo as BaseFileSystemInfo
 from Products.Zuul.interfaces.component import IFileSystemInfo as IBaseFileSystemInfo
 from Products.Zuul.utils import ZuulMessageFactory as _t
+from ZenPacks.zenoss.LinuxMonitor.util import override_graph_labels
 
 
 class FileSystem(BaseFileSystem):
@@ -84,11 +85,14 @@ class FileSystem(BaseFileSystem):
         return "FileSystem"
 
     def getDefaultGraphDefs(self, drange=None):
+        # Add and re-label graphs displayed in other components
         graphs = super(FileSystem, self).getDefaultGraphDefs(drange)
-        underlying = self.logicalVolume() or self.blockDevice()
-        if underlying:
-            for graph in underlying.getDefaultGraphDefs(drange):
-                graphs.append(graph)
+
+        bd = self.logicalVolume() or self.blockDevice()
+        if bd:
+            bdGraphs = override_graph_labels(bd, drange)
+            graphs.extend(bdGraphs)
+
         return graphs
 
     def getGraphObjects(self):

--- a/ZenPacks/zenoss/LinuxMonitor/LogicalVolume.py
+++ b/ZenPacks/zenoss/LinuxMonitor/LogicalVolume.py
@@ -10,6 +10,7 @@
 from zope.interface import implements
 
 from Products.ZenUtils.Utils import prepId
+from ZenPacks.zenoss.LinuxMonitor.util import override_graph_labels
 
 from . import schema
 
@@ -85,13 +86,18 @@ class LogicalVolume(schema.LogicalVolume):
                     return obj
 
     def getDefaultGraphDefs(self, drange=None):
+        # Add and re-label graphs displayed in other components
         graphs = super(LogicalVolume, self).getDefaultGraphDefs(drange)
 
-        graphs.extend(self.volumeGroup().getDefaultGraphDefs(drange))
+        vg = self.volumeGroup()
+        if vg:
+            vgGraphs = override_graph_labels(vg, drange)
+            graphs.extend(vgGraphs)
 
         bd = self.blockDevice()
         if bd:
-            graphs.extend(bd.getDefaultGraphDefs(drange))
+            bdGraphs = override_graph_labels(bd, drange)
+            graphs.extend(bdGraphs)
 
         return graphs
 

--- a/ZenPacks/zenoss/LinuxMonitor/PhysicalVolume.py
+++ b/ZenPacks/zenoss/LinuxMonitor/PhysicalVolume.py
@@ -14,6 +14,7 @@ PhysicalVolume class override
 '''
 
 from . import schema
+from ZenPacks.zenoss.LinuxMonitor.util import override_graph_labels
 
 
 class PhysicalVolume(schema.PhysicalVolume):
@@ -37,11 +38,13 @@ class PhysicalVolume(schema.PhysicalVolume):
             pass
 
     def getDefaultGraphDefs(self, drange=None):
+        # Add and re-label graphs displayed in other components
         graphs = super(PhysicalVolume, self).getDefaultGraphDefs(drange)
 
         bd = self.blockDevice()
         if bd:
-            graphs.extend(bd.getDefaultGraphDefs(drange))
+            bdGraphs = override_graph_labels(bd, drange)
+            graphs.extend(bdGraphs)
 
         return graphs
 

--- a/ZenPacks/zenoss/LinuxMonitor/SnapshotVolume.py
+++ b/ZenPacks/zenoss/LinuxMonitor/SnapshotVolume.py
@@ -10,6 +10,7 @@
 from zope.interface import implements
 
 from Products.ZenUtils.Utils import prepId
+from ZenPacks.zenoss.LinuxMonitor.util import override_graph_labels
 
 from . import schema
 
@@ -88,13 +89,18 @@ class SnapshotVolume(schema.SnapshotVolume):
                     return obj
 
     def getDefaultGraphDefs(self, drange=None):
+        # Add and re-label graphs displayed in other components
         graphs = super(SnapshotVolume, self).getDefaultGraphDefs(drange)
 
-        graphs.extend(self.volumeGroup().getDefaultGraphDefs(drange))
+        vg = self.volumeGroup()
+        if vg:
+            vgGraphs = override_graph_labels(vg, drange)
+            graphs.extend(vgGraphs)
 
         bd = self.blockDevice()
         if bd:
-            graphs.extend(bd.getDefaultGraphDefs(drange))
+            bdGraphs = override_graph_labels(bd, drange)
+            graphs.extend(bdGraphs)
 
         return graphs
 

--- a/ZenPacks/zenoss/LinuxMonitor/VolumeGroup.py
+++ b/ZenPacks/zenoss/LinuxMonitor/VolumeGroup.py
@@ -14,6 +14,7 @@ VolumeGroup class override
 '''
 
 from . import schema
+from ZenPacks.zenoss.LinuxMonitor.util import override_graph_labels
 
 
 class VolumeGroup(schema.VolumeGroup):
@@ -38,10 +39,12 @@ class VolumeGroup(schema.VolumeGroup):
         return '{}'.format(count)
 
     def getDefaultGraphDefs(self, drange=None):
+        # Add and re-label graphs displayed in other components
         graphs = super(VolumeGroup, self).getDefaultGraphDefs(drange)
 
         for pv in self.physicalVolumes():
-            graphs.extend(pv.getDefaultGraphDefs(drange))
+            pvGraphs = override_graph_labels(pv, drange)
+            graphs.extend(pvGraphs)
 
         return graphs
 

--- a/ZenPacks/zenoss/LinuxMonitor/util.py
+++ b/ZenPacks/zenoss/LinuxMonitor/util.py
@@ -173,3 +173,33 @@ class LVMAttributeParser(object):
                 'm': 'mismatches exist',
                 'w': 'writemostly',
                 'X': 'unknown'}.get(att, None)
+
+
+# -----------------------------------------------------------------------------
+# Global Utility Functions
+# -----------------------------------------------------------------------------
+def override_graph_labels(component, drange):
+    # Return a list of modified graphs, given component and drange
+    # Don't modify titles if graphs are already overidden
+
+    graphs = []
+    if not component:
+        return graphs
+
+    for g in component.getDefaultGraphDefs(drange):
+        if not g.get('title_override'):
+
+            title = "{} ({}: {})".format(
+                g["title"],
+                component.class_label,
+                component.titleOrId())
+
+            g = {
+                "title": title,
+                "url": g["url"],
+                "title_override": True,
+                }
+
+        graphs.append(g)
+
+    return graphs


### PR DESCRIPTION
Fixes ZEN-22543.

* Override getDefaultGraphDefs()
* Make all graph['title'] uniq