### PR TITLE
Reformulate commandTemplate for ethernetCsmacd

### DIFF
--- a/ZenPacks/zenoss/LinuxMonitor/zenpack.yaml
+++ b/ZenPacks/zenoss/LinuxMonitor/zenpack.yaml
@@ -578,7 +578,7 @@ device_classes:
                     intf:
                         type: COMMAND
                         usessh: true
-                        commandTemplate: "/bin/bash -c '[[ -x $$(which ifconfig) ]] && ifconfig -a || ip -s -o link'"
+                        commandTemplate: "/bin/sh -c 'export PATH=/bin:/sbin:/usr/bin:/usr/sbin; [ -x $$(which ifconfig) ] && ifconfig -a || ip -s -o link'"
                         parser: ZenPacks.zenoss.LinuxMonitor.parsers.linux.ifconfig
                         component: "${here/id}"
                         eventClass: /Ignore


### PR DESCRIPTION
Fixes ZEN-22544.

* Old command didn't always have path to ifconfig command.
* Used /usr/bin/env PATH=/sbin:/usr/sbin ifconfig -a