### PR TITLE
Fix OS Process in modeler

### DIFF
--- a/ZenPacks/zenoss/LinuxMonitor/modeler/plugins/zenoss/cmd/linux/os_service.py
+++ b/ZenPacks/zenoss/LinuxMonitor/modeler/plugins/zenoss/cmd/linux/os_service.py
@@ -235,7 +235,7 @@ class os_service(LinuxCommandPlugin):
                 services = functions.get('services')(services)
                 processesFunc = functions.get('processes')
             self.populateRelMap(rm, services, regex, processesFunc)
-            log.debug("Init service: %s, results: %s", initService, rm)
+            log.debug("Init service: %s, Relationship: %s", initService, rm.relname)
         else:
             log.info("Can not parse OS services, init service is unknown!")
 


### PR DESCRIPTION
Fixes ZEN-22568

* Fixed bug in os_service logging (debug mode). Getting Traceback: rm is not
  type of object that logging can handle. Resulted in Traceback in debug mode.