### PR TITLE
Truncate title strings in overridden graphs to 34

### DIFF
--- a/ZenPacks/zenoss/LinuxMonitor/util.py
+++ b/ZenPacks/zenoss/LinuxMonitor/util.py
@@ -192,7 +192,8 @@ def override_graph_labels(component, drange):
             title = "{} ({}: {})".format(
                 g["title"],
                 component.class_label,
-                component.titleOrId())
+                component.titleOrId()[:34]
+                )
 
             g = {
                 "title": title,


### PR DESCRIPTION
Fixes ZEN-22593

Some imported graphs have excessively long titles that
were pushing the buttons out of range.