### PR TITLE
Add documentation on sudoers for modeler

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -72,6 +72,7 @@ All Linux servers must have a device entry in an organizer below the <span class
 <span class="tiptitle">Tip:</span>
 The SSH monitoring feature will attempt to use key-based authentication before using a configuration properties password value.
 
+{{ Note }} Make sure the OpenSSH is updated to your distro's current version.
 
 <ol>
 <li>Select Infrastructure from the navigation bar.
@@ -103,15 +104,18 @@ This ZenPack requires the ability to run the ''pvs'', ''vgs'', ''lvs'', ''system
 
 Assuming that you've created a user named '''zenmonitor''' on your linux servers for monitoring purposes, you can follow these steps to allow the '''zenmonitor''' user to run the commands.
 
-# Install the '''sudo''' package on your server.
-# Allow the '''zenmonitor''' user to run the commands via ssh without a TTY.
-## Edit the /etc/sudoers file.
+# Install the '''sudo''' package on your server
+# Allow the '''zenmonitor''' user to run the commands via ssh without a TTY
+## Edit /etc/sudoers.d/zenoss (Or /etc/sudoers if sudoers.d not supported)
 ## Add the following lines to the bottom of the file:
-##: Cmnd_Alias ZENOSS_LVM_CMDS = /usr/sbin/pvs, /usr/sbin/vgs, /usr/sbin/lvs
-##: Cmnd_Alias ZENOSS_SVC_CMDS = /bin/systemctl list-units -t service --all --no-page --no-legend, /bin/systemctl status -l -n 0, /sbin/initctl list, /sbin/service --status-all
-##: zenmonitor ALL=(ALL) NOPASSWD: ZENOSS_LVM_CMDS, ZENOSS_SVC_CMDS
-##: Defaults:zenmonitor        !requiretty
-## Save the changes and exit.
+##:<pre>
+##::Defaults:zenmonitor        !requiretty
+##::Cmnd_Alias ZENOSS_LVM_CMDS = /usr/sbin/pvs, /usr/sbin/vgs, /usr/sbin/lvs
+##::Cmnd_Alias ZENOSS_SVC_CMDS = /bin/systemctl list-units *, \
+##::/bin/systemctl status *, /sbin/initctl list, /sbin/service --status-all, \
+##::/usr/sbin/dmidecode
+##::zenmonitor ALL=(ALL) NOPASSWD: ZENOSS_LVM_CMDS, ZENOSS_SVC_CMDS></pre>
+## Save the changes and exit
 
 
 {| class="wikitable"


### PR DESCRIPTION
Fixes ZEN-22639

* Use wildcards sudo command to allow for xargs sudo
* This is secure because first commands limit use to listing.