### PR TITLE
Ensure modeling on Centos5, Suse 12

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -69,8 +69,6 @@ All Linux servers must have a device entry in an organizer below the <span class
 <span class="tiptitle">Tip:</span>
 The SSH monitoring feature will attempt to use key-based authentication before using a configuration properties password value.
 
-{{ Note }} Make sure the OpenSSH is updated to your distro's current version.
-
 <ol>
 <li>Select Infrastructure from the navigation bar.
 </li>
@@ -97,23 +95,47 @@ This ZenPack requires the ability to run the ''pvs'', ''vgs'', ''lvs'', ''system
 
 
 === Using a Non-Root User ===
-This ZenPack requires the ability to run the ''pvs'', ''vgs'', ''lvs'', ''systemctl'', ''initctl'' and ''service'' commands, remotely on your linux server(s) using SSH. By default, most of these commands are only allowed to be run by the '''root''' user. The output of ''systemctl'', ''initctl'' and ''service'' commands depends on whether they are executed via '''sudo'''. Furthermore, this ZenPack expects these commands be in the user's path. Normally this is only true for the root user.
+This ZenPack requires the ability to run the ''pvs'', ''vgs'', ''lvs'',
+''systemctl'', ''initctl'' and ''service'' commands, remotely on your linux
+server(s) using SSH. By default, most of these commands are only allowed to be
+run by the '''root''' user. The output of ''systemctl'', ''initctl'' and
+''service'' commands depends on whether they are executed via '''sudo'''.
+Furthermore, this ZenPack expects these commands be in the user's path.
+Normally this is only true for the root user.
 
-Assuming that you've created a user named '''zenmonitor''' on your linux servers for monitoring purposes, you can follow these steps to allow the '''zenmonitor''' user to run the commands.
+Assuming that you've created a user named '''zenmonitor''' on your linux
+servers for monitoring purposes, you can follow these steps to allow the
+'''zenmonitor''' user to run the commands.
 
-# Install the '''sudo''' package on your server
-# Allow the '''zenmonitor''' user to run the commands via ssh without a TTY
-## Edit /etc/sudoers.d/zenoss (Or /etc/sudoers if sudoers.d not supported)
-## Add the following lines to the bottom of the file:
-##:<pre>
-##::Defaults:zenmonitor        !requiretty
-##::Cmnd_Alias ZENOSS_LVM_CMDS = /usr/sbin/pvs, /usr/sbin/vgs, /usr/sbin/lvs
-##::Cmnd_Alias ZENOSS_SVC_CMDS = /bin/systemctl list-units *, \
-##::/bin/systemctl status *, /sbin/initctl list, /sbin/service --status-all, \
-##::/usr/sbin/dmidecode
-##::zenmonitor ALL=(ALL) NOPASSWD: ZENOSS_LVM_CMDS, ZENOSS_SVC_CMDS></pre>
-## Save the changes and exit
+<ol>
+<li>Install the '''sudo''' package on your server
+<li>Allow the '''zenmonitor''' user to run the commands via ssh without a TTY
+<ul>
+<li> Edit /etc/sudoers.d/zenoss (Or /etc/sudoers if sudoers.d not supported)
+     and add the following lines to the bottom of the file::
+<div style="margin-left: 1em;">
+<source lang=bash>
+Defaults:zenmonitor        !requiretty
+Cmnd_Alias ZENOSS_LVM_CMDS = /sbin/pvs, /sbin/vgs, /sbin/lvs, \
+                             /usr/sbin/pvs, /usr/sbin/vgs, /usr/sbin/lvs 
+Cmnd_Alias ZENOSS_SVC_CMDS = /bin/systemctl list-units *, \
+      /bin/systemctl status *, /sbin/initctl list, /sbin/service --status-all, \
+      /usr/sbin/dmidecode
+zenmonitor ALL=(ALL) NOPASSWD: ZENOSS_LVM_CMDS, ZENOSS_SVC_CMDS
+</source>
+</div>
+<li> Save, ensuring all paths for these commands are correct
+</ul>
+</ol>
 
+
+{{ Note }} In order for Ssh operation works correctly, ensure OpenSSH is
+updated to your distro's current version. This is especially true for older
+versions of RHEL, CentOS, Ubuntu, and Suse Linux.
+
+{{ Note }} For Suse Linux the paths for (pvs, vgs, lvs) are located at
+/sbin/pvs, /sbin/vgs, and /sbin/lvs respectively. Please ensure that each
+command can be manually executed remotely.
 
 {| class="wikitable"
 |+ <span class="tablecap"><span class="tablecap">Linux Configuration Properties</span></span>

--- a/ZenPacks/zenoss/LinuxMonitor/modeler/plugins/zenoss/cmd/linux/lvm.py
+++ b/ZenPacks/zenoss/LinuxMonitor/modeler/plugins/zenoss/cmd/linux/lvm.py
@@ -82,7 +82,8 @@ class lvm(CommandPlugin):
     MAJ:MIN can be used for diskstats
     """
 
-    command = ('lsblk -rb 2>&1; '
+    command = ('export PATH=/bin:/sbin:/usr/bin:/usr/sbin;'
+               'lsblk -rb 2>&1; '
                'sudo pvs --units b --nosuffix -o pv_name,pv_fmt,pv_attr,pv_size,pv_free,pv_uuid,vg_name 2>&1; '
                'sudo vgs --units b --nosuffix -o vg_name,vg_attr,vg_size,vg_free,vg_uuid 2>&1; '
                'sudo lvs --units b --nosuffix -o lv_name,vg_name,lv_attr,lv_size,lv_uuid,origin 2>&1 ')


### PR DESCRIPTION
Fixes ZEN-22639

* Reformat wiki documentation to make more legible
* Add in docs for more robust /etc/sudoers
* Add needed PATH export for modeler/plugins/zenoss/cmd/linux/lvm.py