### PR TITLE
Fixes ZEN-18605.

### DIFF
--- a/ZenPacks/zenoss/LinuxMonitor/zenpack.yaml
+++ b/ZenPacks/zenoss/LinuxMonitor/zenpack.yaml
@@ -582,6 +582,7 @@ device_classes:
                             Written:
                                 dpName: io_ssIORawSent
                                 format: "%7.2lf%s"
+                                color: 98df8a
 
             ethernetCsmacd:
                 description: "Ethernet (and default) network interface monitoring for Linux via SSH."


### PR DESCRIPTION
IO Throughput graph's Written datapoint has been updated with a custom color.