### PR TITLE
Feature/zen 23338

### DIFF
--- a/ZenPacks/zenoss/LinuxMonitor/modeler/plugins/zenoss/cmd/linux/lvm.py
+++ b/ZenPacks/zenoss/LinuxMonitor/modeler/plugins/zenoss/cmd/linux/lvm.py
@@ -82,7 +82,7 @@ class lvm(CommandPlugin):
     MAJ:MIN can be used for diskstats
     """
 
-    command = ('export PATH=/bin:/sbin:/usr/bin:/usr/sbin;'
+    command = ('export PATH=/bin:/sbin:/usr/bin:/usr/sbin; '
                'lsblk -rb 2>&1; '
                'sudo pvs --units b --nosuffix -o pv_name,pv_fmt,pv_attr,pv_size,pv_free,pv_uuid,vg_name 2>&1; '
                'sudo vgs --units b --nosuffix -o vg_name,vg_attr,vg_size,vg_free,vg_uuid 2>&1; '

--- a/ZenPacks/zenoss/LinuxMonitor/tests/plugindata/lvm
+++ b/ZenPacks/zenoss/LinuxMonitor/tests/plugindata/lvm
@@ -1,4 +1,4 @@
-lsblk -rb 2>&1; sudo pvs --units b --nosuffix -o pv_name,pv_fmt,pv_attr,pv_size,pv_free,pv_uuid,vg_name 2>&1; sudo vgs --units b --nosuffix -o vg_name,vg_attr,vg_size,vg_free,vg_uuid 2>&1; sudo lvs --units b --nosuffix -o lv_name,vg_name,lv_attr,lv_size,lv_uuid,origin 2>&1 
+export PATH=/bin:/sbin:/usr/bin:/usr/sbin; lsblk -rb 2>&1; sudo pvs --units b --nosuffix -o pv_name,pv_fmt,pv_attr,pv_size,pv_free,pv_uuid,vg_name 2>&1; sudo vgs --units b --nosuffix -o vg_name,vg_attr,vg_size,vg_free,vg_uuid 2>&1; sudo lvs --units b --nosuffix -o lv_name,vg_name,lv_attr,lv_size,lv_uuid,origin 2>&1
 NAME MAJ:MIN RM SIZE RO TYPE MOUNTPOINT
 sda 8:0 0 21474836480 0 disk
 PV         Fmt  Attr PSize       PFree      PV UUID                                VG

--- a/ZenPacks/zenoss/LinuxMonitor/tests/test_dvi.py
+++ b/ZenPacks/zenoss/LinuxMonitor/tests/test_dvi.py
@@ -7,11 +7,27 @@
 #
 ##############################################################################
 
+import unittest
+
 from Products.DataCollector.plugins.DataMaps import ObjectMap, RelationshipMap
 
 from ZenPacks.zenoss.LinuxMonitor import zenpacklib
 from ZenPacks.zenoss.LinuxMonitor.tests import utils as tu
 
+# DynamicView Imports
+try:
+    from ZenPacks.zenoss.DynamicView import TAG_IMPACTED_BY, TAG_IMPACTS
+    DYNAMICVIEW_INSTALLED = True
+except ImportError:
+    TAG_IMPACTED_BY, TAG_IMPACTS = None, None
+    DYNAMICVIEW_INSTALLED = False
+
+# Impact Import
+try:
+    import ZenPacks.zenoss.Impact
+    IMPACT_INSTALLED = True
+except ImportError:
+    IMPACT_INSTALLED = False
 
 # These are the DynamicView/Impact impactful relationships we'll test for.
 EXPECTED_IMPACTS = """
@@ -264,12 +280,8 @@ class TestDVI(zenpacklib.TestCase):
             "test-linux1",
             DATAMAPS)
 
+    @unittest.skipUnless(DYNAMICVIEW_INSTALLED, "DynamicView not installed")
     def test_DynamicView_Impacts(self):
-        try:
-            from ZenPacks.zenoss.DynamicView import TAG_IMPACTED_BY, TAG_IMPACTS
-        except ImportError:
-            self.fail("DynamicView must be installed to run this test")
-
         expected = tu.triples_from_yuml(EXPECTED_IMPACTS)
         all_expected = tu.complement_triples(expected)
 
@@ -296,13 +308,8 @@ class TestDVI(zenpacklib.TestCase):
                         TAG_IMPACTS: TAG_IMPACTED_BY,
                         })))
 
+    @unittest.skipUnless(DYNAMICVIEW_INSTALLED and IMPACT_INSTALLED, "DynamicView and Impact are not installed")
     def test_Impact_Edges(self):
-        try:
-            from ZenPacks.zenoss.DynamicView import TAG_IMPACTED_BY, TAG_IMPACTS
-            import ZenPacks.zenoss.Impact  # NOQA
-        except ImportError:
-            self.fail("DynamicView and Impact must be installed to run this test")
-
         expected = tu.triples_from_yuml(EXPECTED_IMPACTS)
         all_expected = tu.complement_triples(expected)
         found = tu.impact_triples_from_device(self.device)

--- a/ZenPacks/zenoss/LinuxMonitor/tests/test_dvi.py
+++ b/ZenPacks/zenoss/LinuxMonitor/tests/test_dvi.py
@@ -308,7 +308,8 @@ class TestDVI(zenpacklib.TestCase):
                         TAG_IMPACTS: TAG_IMPACTED_BY,
                         })))
 
-    @unittest.skipUnless(DYNAMICVIEW_INSTALLED and IMPACT_INSTALLED, "DynamicView and Impact are not installed")
+    @unittest.skipUnless(DYNAMICVIEW_INSTALLED and IMPACT_INSTALLED,
+                         "DynamicView and Impact are not installed")
     def test_Impact_Edges(self):
         expected = tu.triples_from_yuml(EXPECTED_IMPACTS)
         all_expected = tu.complement_triples(expected)


### PR DESCRIPTION
# ZEN-23338: Fix broken unit tests

There were 2 broken tests:
- the lvm plugin test requires the first line of the ..tests/plugindata/lvm file to correspond to the command in ..modeler/plugins/zenoss/cmd/linux/lvm.py. A command had been added to the python file, but the unit test had not been updated. Also, the test is sensitive to spaces in the .py file, so I had to add a space there to match the expected value.
- the tests in ...tests/test_dvi.py requre Impact and DynamicView to pass. Impact is not present in NFVI. I updated the tests to skip if the prerequisites are not present, rather than failing (i.e. don't run the tests if they are not applicable to the current environment).

# Demo:
```
(zenoss)[zenoss@ffb1ce9854b2 ~]$ runtests --type unit ZenPacks.zenoss.LinuxMonitor
==============================

Packages to be tested:
	ZenPacks.zenoss.LinuxMonitor

==============================
Parsing /opt/zenoss/etc/zope.conf
2016-06-02 16:05:35 WARNING zen.zenpacklib ZenPacks.zenoss.OpenStackInfrastructure: Instance custom columns exceed 750 pixels (850)
Running tests at level 1
Running Products.ZenTestCase.BaseTestCase.ZenossTestCaseLayer tests:
  Set up Testing.ZopeTestCase.layer.ZopeLite in 0.141 seconds.
  Set up Products.ZenTestCase.BaseTestCase.ZenossTestCaseLayer in 0.001 seconds.
  Running:
.testParsers made 61 assertions.
.testPlugins made 65 assertions.
..
  Ran 4 tests with 0 failures and 0 errors in 6.510 seconds.
Tearing down left over layers:
  Tear down Products.ZenTestCase.BaseTestCase.ZenossTestCaseLayer in 0.000 seconds.
  Tear down Testing.ZopeTestCase.layer.ZopeLite in 0.000 seconds.
(zenoss)[zenoss@ffb1ce9854b2 ~]$ 
```
