### PR TITLE
Prevent thresholds on NICs with unknown speed

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -486,8 +486,10 @@ The following flavors of Linux are supported
 
 == Changes ==
 
-=== 2.0.0 ===
+;2.1.0
+* Prevent threshold violations on interfaces with unknown speed.
 
+;2.0.0
 * Added support for LVM Physical Volumes, Volume Groups, and Logical Volumes
 * Added support for OpenStack-LVM Integration
 * Added disk (block device) monitoring.

--- a/ZenPacks/zenoss/LinuxMonitor/zenpack.yaml
+++ b/ZenPacks/zenoss/LinuxMonitor/zenpack.yaml
@@ -677,7 +677,7 @@ device_classes:
                 thresholds:
                     "75 percent utilization":
                         type: MinMaxThreshold
-                        maxval: "(here.speed or 1e7) / 8 * .75"
+                        maxval: "(here.speed or 1e12) / 8 * .75"
                         eventClass: /Perf/Interface
                         dsnames:
                             - intf_ifInOctets


### PR DESCRIPTION
Previously we were assuming interfaces without a known speed were
10Mbps. This seems like a really bad guess, and as of 29d94c9 we are
much better able to determine the speed of interfaces.

This change to assume a 1Tbps interface speed in the absence of a known
speed is intended to prevent any threshold violations on interfaces for
which we still don't know the speed. This would apply to special
interface types like bridges. For bridges we're getting usage and speed
from the member interfaces anyway.