### PR TITLE
Fix typo in /Perf/Filesystem threshold

### DIFF
--- a/ZenPacks/zenoss/LinuxMonitor/zenpack.yaml
+++ b/ZenPacks/zenoss/LinuxMonitor/zenpack.yaml
@@ -782,7 +782,7 @@ device_classes:
                     "90 percent used":
                         type: MinMaxThreshold
                         maxval: "here.getTotalBlocks() * 0.90"
-                        eventClass: /Perf/FileSystem
+                        eventClass: /Perf/Filesystem
                         dsnames:
                             - disk_usedBlocks
 


### PR DESCRIPTION
/Perf/FileSystem is not an event class that will exist. It should be
/Perf/Filesystem instead. This will result in a broken link from the
event console's event class column when the event is generated. It will
also result in nothing being chosen in the threshold's event class
field when edited.