### PR TITLE
Add zIgnoreUnmounted property to ignore unmounted hard disks

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -29,6 +29,10 @@ to every 12 hours.
 not available, in which case this component will be missing.
 </div>
 
+<div style="margin-left: 2em;">
+{{ Note }} To ignore unmounted drives, set the zIgnoreUnmounted configuration property to True.
+</div>
+
 ;Processors
 : Attributes: Socket, Manufacturer, Model, Speed, Ext Speed, L1, L2, Voltage
 
@@ -509,6 +513,9 @@ The following flavors of Linux are supported
 |}
 
 == Changes ==
+
+;2.0.2
+* Added property to ignore unmounted hard disks
 
 ;2.0.1
 * Fix invalid event class in filesystem threshold

--- a/ZenPacks/zenoss/LinuxMonitor/modeler/plugins/zenoss/cmd/linux/lvm.py
+++ b/ZenPacks/zenoss/LinuxMonitor/modeler/plugins/zenoss/cmd/linux/lvm.py
@@ -26,6 +26,11 @@ log = logging.getLogger('zen.lvm')
 
 
 class lvm(CommandPlugin):
+
+    deviceProperties = CommandPlugin.deviceProperties + (
+        'zIgnoreUnmounted',
+    )
+
     """
     /usr/bin/fdisk -l  | grep '^Disk' | grep -v 'mapper\|identifier\|label' | awk '{gsub(":","");print $2" "$5}'
     /usr/bin/sudo pvs --units b --nosuffix -o pv_name,pv_fmt,pv_attr,pv_size,pv_free,pv_uuid,vg_name;
@@ -89,6 +94,7 @@ class lvm(CommandPlugin):
                'sudo lvs --units b --nosuffix -o lv_name,vg_name,lv_attr,lv_size,lv_uuid,origin 2>&1 ')
 
     def process(self, device, results, log):
+        ignore_unmounted = getattr(device, 'zIgnoreUnmounted', None)
         hd_maps = []
         pv_maps = []
         vg_maps = []
@@ -143,7 +149,8 @@ class lvm(CommandPlugin):
                 if any(columns['device_block'] == om.title for om in hd_maps):
                     continue
                 if columns['type'] in ('disk', 'lvm', 'part', 'raid1'):
-                    hd_maps.append(self.makeHDMap(columns))
+                    if columns['mount'] or not ignore_unmounted:
+                        hd_maps.append(self.makeHDMap(columns))
 
         maps = []
         maps.append(RelationshipMap(

--- a/ZenPacks/zenoss/LinuxMonitor/zenpack.yaml
+++ b/ZenPacks/zenoss/LinuxMonitor/zenpack.yaml
@@ -1,5 +1,11 @@
 name: ZenPacks.zenoss.LinuxMonitor
 
+zProperties:
+    zIgnoreUnmounted:
+        category: Modeler Controls
+        type: boolean
+        default: false
+
 classes:
     DEFAULTS:
         base: [zenpacklib.Component]


### PR DESCRIPTION
For devices that may have hundreds of unmounted disks, there is no need to model/monitor them.

Cherry picked from 58854054b593c20e455772cfc4168538e8b636d6 to get into a hotfix