### PR TITLE
Fix NewDeviceType migration

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -514,6 +514,9 @@ The following flavors of Linux are supported
 
 == Changes ==
 
+;2.0.3
+* Fix migration of Linux devices to new type. (ZEN-24293)
+
 ;2.0.2
 * Added property to ignore unmounted hard disks
 * Improve 1.x to 2.x migration time. (ZEN-24024)


### PR DESCRIPTION
The NewDeviceType migration optimization (8a311e2) seems to fail in
changing the class of Linux devices from Device
(Products.ZenModel.Device.Device) to LinuxDevice
(ZenPacks.zenoss.LinuxMonitor.LinuxDevice.LinuxDevice) due to ZODB not
storing the change to the device's __class__ attribute. It appears that
the change is successful, but upon reloading the Zope client, __class__
is reset back to its original value.

This is apparently a known behavior of ZODB, but there is a workaround.
This commit uses that workaround to also replace the object's persistent
reference and cause the __class__ change to be permanent.

Fixes ZEN-24293.