### PR TITLE
Only patch Conch on Twisted earlier than 15

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -514,6 +514,9 @@ The following flavors of Linux are supported
 
 == Changes ==
 
+;2.0.4
+* Fix "unimplemented" SSH error on 4.2.5 SP709. (ZEN-23392)
+
 ;2.0.3
 * Fix migration of Linux devices to new type. (ZEN-24293)
 

--- a/ZenPacks/zenoss/LinuxMonitor/patches/__init__.py
+++ b/ZenPacks/zenoss/LinuxMonitor/patches/__init__.py
@@ -8,7 +8,10 @@
 ##############################################################################
 
 import logging
+import twisted
 from importlib import import_module
+from pkg_resources import parse_version
+
 LOG = logging.getLogger('zen.LinuxMonitor')
 
 
@@ -27,5 +30,8 @@ def optional_import(module_name, patch_module_name):
             LOG.exception("failed to apply %s patches", patch_module_name)
 
 
-optional_import('twisted.conch', 'twistedConch')
 optional_import('Products.ZenModel', 'platform')
+
+# We only need to patch Conch in Twisted versions earlier than 15.
+if parse_version(twisted.__version__) < parse_version("15"):
+    optional_import('twisted.conch', 'twistedConch')


### PR DESCRIPTION
The patch is backporting changes from Twisted 15. So there's no reason
to do it if the platform already includes Twisted 15.

Refs ZEN-23392.