### PR TITLE
Fix testPlugins and TestDVI unit tests

### DIFF
--- a/ZenPacks/zenoss/LinuxMonitor/tests/plugindata/lvm
+++ b/ZenPacks/zenoss/LinuxMonitor/tests/plugindata/lvm
@@ -1,4 +1,4 @@
-lsblk -rb 2>&1; sudo pvs --units b --nosuffix -o pv_name,pv_fmt,pv_attr,pv_size,pv_free,pv_uuid,vg_name 2>&1; sudo vgs --units b --nosuffix -o vg_name,vg_attr,vg_size,vg_free,vg_uuid 2>&1; sudo lvs --units b --nosuffix -o lv_name,vg_name,lv_attr,lv_size,lv_uuid,origin 2>&1 
+export PATH=/bin:/sbin:/usr/bin:/usr/sbin;lsblk -rb 2>&1; sudo pvs --units b --nosuffix -o pv_name,pv_fmt,pv_attr,pv_size,pv_free,pv_uuid,vg_name 2>&1; sudo vgs --units b --nosuffix -o vg_name,vg_attr,vg_size,vg_free,vg_uuid 2>&1; sudo lvs --units b --nosuffix -o lv_name,vg_name,lv_attr,lv_size,lv_uuid,origin 2>&1
 NAME MAJ:MIN RM SIZE RO TYPE MOUNTPOINT
 sda 8:0 0 21474836480 0 disk
 PV         Fmt  Attr PSize       PFree      PV UUID                                VG

--- a/ZenPacks/zenoss/LinuxMonitor/tests/test_dvi.py
+++ b/ZenPacks/zenoss/LinuxMonitor/tests/test_dvi.py
@@ -7,10 +7,25 @@
 #
 ##############################################################################
 
+import unittest
+
 from Products.DataCollector.plugins.DataMaps import ObjectMap, RelationshipMap
 
 from ZenPacks.zenoss.LinuxMonitor import zenpacklib
 from ZenPacks.zenoss.LinuxMonitor.tests import utils as tu
+
+try:
+    from ZenPacks.zenoss.DynamicView import TAG_IMPACTED_BY, TAG_IMPACTS
+    DYNAMICVIEW_INSTALLED = True
+except ImportError:
+    TAG_IMPACTED_BY, TAG_IMPACTS = None, None
+    DYNAMICVIEW_INSTALLED = False
+
+try:
+    import ZenPacks.zenoss.Impact  # NOQA
+    IMPACT_INSTALLED = True
+except ImportError:
+    IMPACT_INSTALLED = False
 
 
 # These are the DynamicView/Impact impactful relationships we'll test for.
@@ -264,12 +279,8 @@ class TestDVI(zenpacklib.TestCase):
             "test-linux1",
             DATAMAPS)
 
+    @unittest.skipUnless(DYNAMICVIEW_INSTALLED, "DynamicView not installed")
     def test_DynamicView_Impacts(self):
-        try:
-            from ZenPacks.zenoss.DynamicView import TAG_IMPACTED_BY, TAG_IMPACTS
-        except ImportError:
-            self.fail("DynamicView must be installed to run this test")
-
         expected = tu.triples_from_yuml(EXPECTED_IMPACTS)
         all_expected = tu.complement_triples(expected)
 
@@ -296,13 +307,8 @@ class TestDVI(zenpacklib.TestCase):
                         TAG_IMPACTS: TAG_IMPACTED_BY,
                         })))
 
+    @unittest.skipUnless(IMPACT_INSTALLED, "Impact not installed")
     def test_Impact_Edges(self):
-        try:
-            from ZenPacks.zenoss.DynamicView import TAG_IMPACTED_BY, TAG_IMPACTS
-            import ZenPacks.zenoss.Impact  # NOQA
-        except ImportError:
-            self.fail("DynamicView and Impact must be installed to run this test")
-
         expected = tu.triples_from_yuml(EXPECTED_IMPACTS)
         all_expected = tu.complement_triples(expected)
         found = tu.impact_triples_from_device(self.device)


### PR DESCRIPTION
No problems in the code being tested. Just problems in the unit tests.

- testPlugins failed due to a slight change in the command being run.
- TestDVI was expecting DynamicView and Impact to be installed.

These tests have already been fixed on the develop branch. Fixing them
again in a hotfix so we can keep Zenoss 5.2 tests passing with a stable
version of LinuxMonitor.

ZEN-24653 will only be fixed once LinuxMonitor 2.0.5 is released with
this fix.