### PR TITLE
Remove lines starting with #

### DIFF
--- a/ZenPacks/zenoss/LinuxMonitor/modeler/plugins/zenoss/cmd/linux/alt_kernel_name.py
+++ b/ZenPacks/zenoss/LinuxMonitor/modeler/plugins/zenoss/cmd/linux/alt_kernel_name.py
@@ -36,7 +36,11 @@ Kernel \r on an \m
             return
 
         log.debug("Results = %s", results.split('\n'))
-
+        fixed_res = ""
+        for line in results.split('\n'):
+                if not line.startswith("#"):
+                        fixed_res += line
+        results = fixed_res                
         om = self.objectMap()
         om.setOSProductKey = results
         log.debug("setOSProductKey = %s", om.setOSProductKey)


### PR DESCRIPTION
Found that customized etc issue with an MOTD style message cause errors:

File "/opt/zenoss/lib/python2.7/site-packages/OFS/ObjectManager.py", line 105, in checkValidId
    'The id "%s" is invalid because it ends with two underscores.' % id)
BadRequest: The id "Red Hat Enterprise Linux Server release 6.5 (Santiago)_Kernel _r on an _m___________________________________________________________________________________                                                                         _____ This computer system is for authorized use only.  Users (authorized or  _____ unauthorized) have no explicit or implicit expectation of privacy.  Any _____ or all use of this system and all files on this system may be           _____ intercepted, monitored, recorded, copied, audited, inspected and        _____ disclosed to authorized IT personnel, law enforcement, as well as       _____ officials of other agencies, both domestic and foreign without prior    _____ notice.  By using this system, the user consents to such interception,  _____ monitoring, recording, copying, auditing and inspection.                _____                                                                         _____  This file is managed by puppet, do not manually edit.                  _____" is invalid because it ends with two underscores.