### PR TITLE
Update Unit tests to support ZPL2 (ZEN-26151)

### DIFF
--- a/ZenPacks/zenoss/LinuxMonitor/tests/test_NewDeviceType.py
+++ b/ZenPacks/zenoss/LinuxMonitor/tests/test_NewDeviceType.py
@@ -11,18 +11,23 @@
 
 import datetime
 
-from Products.DataCollector.plugins.DataMaps import ObjectMap, RelationshipMap
+# Zenoss Imports
+import Globals  # noqa
+from Products.ZenUtils.Utils import unused
+
+unused(Globals)
+
+from Products.ZenTestCase.BaseTestCase import BaseTestCase
+
+from Products.DataCollector.plugins.DataMaps import RelationshipMap
 from Products.ZenModel.Device import Device
 
-from .. import zenpacklib
-from .. import ZenPack
-from ..LinuxDevice import LinuxDevice
-from ..migrate.NewDeviceType import NewDeviceType
+from ZenPacks.zenoss.LinuxMonitor import ZenPack
+from ZenPacks.zenoss.LinuxMonitor.LinuxDevice import LinuxDevice
+from ZenPacks.zenoss.LinuxMonitor.migrate.NewDeviceType import NewDeviceType
 
-from .utils import create_device
-from .test_dvi import DATAMAPS as NEW_DATAMAPS
-
-zenpacklib.enableTesting()
+from ZenPacks.zenoss.LinuxMonitor.tests.utils import create_device
+from ZenPacks.zenoss.LinuxMonitor.tests.test_dvi import DATAMAPS as NEW_DATAMAPS
 
 
 OLD_DATAMAPS = [
@@ -52,7 +57,7 @@ OLD_DATAMAPS = [
 ]
 
 
-class migrateTests(zenpacklib.TestCase):
+class migrateTests(BaseTestCase):
     """Tests for NewDeviceType.migrate."""
 
     def afterSetUp(self):
@@ -149,3 +154,16 @@ class migrateTests(zenpacklib.TestCase):
             "{} devices took to long to migrate ({})".format(
                 count,
                 duration))
+
+def test_suite():
+    """Return test suite for this module."""
+    from unittest import TestSuite, makeSuite
+    suite = TestSuite()
+    suite.addTest(makeSuite(migrateTests))
+    return suite
+
+
+if __name__ == "__main__":
+    from zope.testrunner.runner import Runner
+    runner = Runner(found_suites=[test_suite()])
+    runner.run()

--- a/ZenPacks/zenoss/LinuxMonitor/tests/test_dvi.py
+++ b/ZenPacks/zenoss/LinuxMonitor/tests/test_dvi.py
@@ -6,12 +6,16 @@
 # License.zenoss under the directory where your Zenoss product is installed.
 #
 ##############################################################################
-
 import unittest
 
-from Products.DataCollector.plugins.DataMaps import ObjectMap, RelationshipMap
+# Zenoss Imports
+import Globals  # noqa
+from Products.ZenUtils.Utils import unused
 
-from ZenPacks.zenoss.LinuxMonitor import zenpacklib
+unused(Globals)
+
+from Products.DataCollector.plugins.DataMaps import ObjectMap, RelationshipMap
+from ZenPacks.zenoss.ZenPackLib.lib.tests.TestCase import TestCase
 from ZenPacks.zenoss.LinuxMonitor.tests import utils as tu
 
 try:
@@ -260,11 +264,8 @@ DATAMAPS = [
 ]
 
 
-# Testing must be enabled before zenpacklib.TestCase can be used.
-zenpacklib.enableTesting()
 
-
-class TestDVI(zenpacklib.TestCase):
+class TestDVI(TestCase):
 
     def afterSetUp(self):
         super(TestDVI, self).afterSetUp()
@@ -326,3 +327,16 @@ class TestDVI(zenpacklib.TestCase):
                     tag_map={
                         TAG_IMPACTS: TAG_IMPACTED_BY,
                         })))
+
+def test_suite():
+    """Return test suite for this module."""
+    from unittest import TestSuite, makeSuite
+    suite = TestSuite()
+    suite.addTest(makeSuite(TestDVI))
+    return suite
+
+
+if __name__ == "__main__":
+    from zope.testrunner.runner import Runner
+    runner = Runner(found_suites=[test_suite()])
+    runner.run()


### PR DESCRIPTION
- Fixes ZEN-26151
- Updated imports for TestCase and others
- Enable tests to run from command line