### PR TITLE
Fix unit test missing module name

### DIFF
--- a/ZenPacks/zenoss/LinuxMonitor/tests/test_NewDeviceType.py
+++ b/ZenPacks/zenoss/LinuxMonitor/tests/test_NewDeviceType.py
@@ -17,17 +17,17 @@ from Products.ZenUtils.Utils import unused
 
 unused(Globals)
 
-from Products.ZenTestCase.BaseTestCase import BaseTestCase
-
 from Products.DataCollector.plugins.DataMaps import RelationshipMap
 from Products.ZenModel.Device import Device
 
-from ZenPacks.zenoss.LinuxMonitor import ZenPack
+from ZenPacks.zenoss.LinuxMonitor import zenpacklib, ZenPack
 from ZenPacks.zenoss.LinuxMonitor.LinuxDevice import LinuxDevice
 from ZenPacks.zenoss.LinuxMonitor.migrate.NewDeviceType import NewDeviceType
 
 from ZenPacks.zenoss.LinuxMonitor.tests.utils import create_device
 from ZenPacks.zenoss.LinuxMonitor.tests.test_dvi import DATAMAPS as NEW_DATAMAPS
+
+zenpacklib.enableTesting()
 
 
 OLD_DATAMAPS = [
@@ -57,7 +57,7 @@ OLD_DATAMAPS = [
 ]
 
 
-class migrateTests(BaseTestCase):
+class migrateTests(zenpacklib.TestCase):
     """Tests for NewDeviceType.migrate."""
 
     def afterSetUp(self):
@@ -155,15 +155,3 @@ class migrateTests(BaseTestCase):
                 count,
                 duration))
 
-def test_suite():
-    """Return test suite for this module."""
-    from unittest import TestSuite, makeSuite
-    suite = TestSuite()
-    suite.addTest(makeSuite(migrateTests))
-    return suite
-
-
-if __name__ == "__main__":
-    from zope.testrunner.runner import Runner
-    runner = Runner(found_suites=[test_suite()])
-    runner.run()

--- a/ZenPacks/zenoss/LinuxMonitor/tests/test_dvi.py
+++ b/ZenPacks/zenoss/LinuxMonitor/tests/test_dvi.py
@@ -6,17 +6,13 @@
 # License.zenoss under the directory where your Zenoss product is installed.
 #
 ##############################################################################
+
 import unittest
 
-# Zenoss Imports
-import Globals  # noqa
-from Products.ZenUtils.Utils import unused
-
-unused(Globals)
-
 from Products.DataCollector.plugins.DataMaps import ObjectMap, RelationshipMap
-from ZenPacks.zenoss.ZenPackLib.lib.tests.TestCase import TestCase
-from ZenPacks.zenoss.LinuxMonitor.tests import utils as tu
+
+from ZenPacks.zenoss.LinuxMonitor import zenpacklib
+from . import utils as tu
 
 try:
     from ZenPacks.zenoss.DynamicView import TAG_IMPACTED_BY, TAG_IMPACTS
@@ -264,8 +260,11 @@ DATAMAPS = [
 ]
 
 
+# Testing must be enabled before zenpacklib.TestCase can be used.
+zenpacklib.enableTesting()
 
-class TestDVI(TestCase):
+
+class TestDVI(zenpacklib.TestCase):
 
     def afterSetUp(self):
         super(TestDVI, self).afterSetUp()
@@ -328,15 +327,3 @@ class TestDVI(TestCase):
                         TAG_IMPACTS: TAG_IMPACTED_BY,
                         })))
 
-def test_suite():
-    """Return test suite for this module."""
-    from unittest import TestSuite, makeSuite
-    suite = TestSuite()
-    suite.addTest(makeSuite(TestDVI))
-    return suite
-
-
-if __name__ == "__main__":
-    from zope.testrunner.runner import Runner
-    runner = Runner(found_suites=[test_suite()])
-    runner.run()


### PR DESCRIPTION
Fixes ZEN-26200

TestCase has been added back to zpl2 for backwards compatibility.