### PR TITLE
Use 'ip addr' command before ifconfig

### DIFF
--- a/ZenPacks/zenoss/LinuxMonitor/modeler/plugins/zenoss/cmd/linux/interfaces.py
+++ b/ZenPacks/zenoss/LinuxMonitor/modeler/plugins/zenoss/cmd/linux/interfaces.py
@@ -95,10 +95,10 @@ class interfaces(LinuxCommandPlugin):
 
     # echo __COMMAND__ is used to delimit the results
     command = 'export PATH=$PATH:/sbin:/usr/sbin; \
-               if which ifconfig >/dev/null 2>&1; then \
-                   ifconfig -a; \
-               elif which ip >/dev/null 2>&1; then \
+               if which ip >/dev/null 2>&1; then \
                    echo "### ip addr output"; ip addr; \
+               elif which ifconfig >/dev/null 2>&1; then \
+                   ifconfig -a; \
                else \
                    echo "No ifconfig or ip utilities were found."; exit 127; \
                fi \

--- a/ZenPacks/zenoss/LinuxMonitor/zenpack.yaml
+++ b/ZenPacks/zenoss/LinuxMonitor/zenpack.yaml
@@ -605,7 +605,7 @@ device_classes:
                     intf:
                         type: COMMAND
                         usessh: true
-                        commandTemplate: "/bin/sh -c 'export PATH=/bin:/sbin:/usr/bin:/usr/sbin; [ -x $$(which ifconfig) ] && ifconfig -a || ip -s -o link'"
+                        commandTemplate: "/bin/sh -c 'export PATH=/bin:/sbin:/usr/bin:/usr/sbin; if which ip >/dev/null 2>&1; then ip -s -o link; else ifconfig -a; fi'"
                         parser: ZenPacks.zenoss.LinuxMonitor.parsers.linux.ifconfig
                         component: "${here/id}"
                         eventClass: /Ignore


### PR DESCRIPTION
Fixes ZEN-25425

Some installations can have both ifconfig and ip addr.  We should
be using ip addr before ifconfig as ifconfig can show bad results