### PR TITLE
Add link to storage disk/lun for hard disk

### DIFF
--- a/ZenPacks/zenoss/LinuxMonitor/HardDisk.py
+++ b/ZenPacks/zenoss/LinuxMonitor/HardDisk.py
@@ -10,6 +10,8 @@
 import itertools
 
 from Products.ZenUtils.Utils import prepId
+from Products.Zuul.interfaces import ICatalogTool
+from Products.AdvancedQuery import Eq, Or
 
 from . import schema
 
@@ -76,3 +78,17 @@ class HardDisk(schema.HardDisk):
         lv = self.logicalVolume()
         if lv:
             return lv
+
+    def storage_disk_lun(self):
+        # return the UCS storage disk/virtual drive
+        # if disk_ids contains the IDs of disk/virtual drive
+        if self.disk_ids:
+            results = ICatalogTool(self.getDmdRoot('Devices')).search(
+                query=Or(*[Eq('searchKeywords', id)
+                           for id in self.disk_ids]))
+
+            for brain in results:
+                try:
+                    yield brain.getObject()
+                except Exception:
+                    continue

--- a/ZenPacks/zenoss/LinuxMonitor/zenpack.yaml
+++ b/ZenPacks/zenoss/LinuxMonitor/zenpack.yaml
@@ -346,6 +346,15 @@ classes:
                 type: lines
                 index_type: keyword
 
+            storage_disk_lun:
+                # link to storage disk/virtual drive
+                # if the hard disk is actually mapped to it
+                label: Storage Disk/LUN
+                type: entity
+                grid_display: false
+                api_only: true
+                api_backendtype: method
+
         dynamicview_views: [service_view]
         dynamicview_weight: 40
         dynamicview_relations:

--- a/ZenPacks/zenoss/LinuxMonitor/zenpack.yaml
+++ b/ZenPacks/zenoss/LinuxMonitor/zenpack.yaml
@@ -351,7 +351,6 @@ classes:
                 # if the hard disk is actually mapped to it
                 label: Storage Disk/LUN
                 type: entity
-                grid_display: false
                 api_only: true
                 api_backendtype: method
 


### PR DESCRIPTION
Fixes ZPS-939

If the link to the storage disk/lun can be found, add the link
to hard disk details.