### PR TITLE
Update README.rst to prevent confusion

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ Features
 
 .. Note::
    This version of LinuxMonitor fully replaces EnterpriseLinux. To avoid
-   related errors in zenhub logs, EnterpriseLinux ZP should be removed.
+   related errors in zenhub logs, EnterpriseLinux ZP should be removed after the new LinuxMonitor has been applied.
 
 Discovery
 ~~~~~~~~~


### PR DESCRIPTION
The README advises removing the EnterpriseLinux ZenPack but is not specific about when to remove it. This has resulted in the EnterpriseLinux ZenPack being removed before the new LinuxMonitor ZenPack has been loaded, causing removal of /Server/SSH/Linux devices/