### PR TITLE
ZEN-26739 Unable to selectively adjust zFileSystemSizeOffset based on…

### DIFF
--- a/ZenPacks/zenoss/LinuxMonitor/zenpack.yaml
+++ b/ZenPacks/zenoss/LinuxMonitor/zenpack.yaml
@@ -776,6 +776,9 @@ device_classes:
                                     fs_used__bytes: "${here/blockSize},*"
                                     usedFilesystemSpace__bytes: "${here/blockSize},*"
 
+                            availBlocks:
+                                rrdmin: 0
+
                     idisk:
                         type: COMMAND
                         usessh: true


### PR DESCRIPTION
… FS type.

Missed the fact that we have similar data sources which uses same df -kP command for different components.