### PR TITLE
Reduce unnecessary QueryService calls (ZPS-1312)

### DIFF
--- a/ZenPacks/zenoss/LinuxMonitor/FileSystem.py
+++ b/ZenPacks/zenoss/LinuxMonitor/FileSystem.py
@@ -40,39 +40,6 @@ class FileSystem(schema.FileSystem):
     Instances of this class get stored in ZODB.
     """
 
-    def getTotalBlocks(self):
-
-        availBlocks = self.cacheRRDValue('availBlocks', None)
-        usedBlocks = self.usedBlocks()
-        if availBlocks is not None and usedBlocks is not None:
-            nonRootTotalBlocks = availBlocks + usedBlocks
-            return nonRootTotalBlocks
-
-        offset = getattr(self.primaryAq(), 'zFileSystemSizeOffset', 1.0)
-        return int(self.totalBlocks) * offset
-
-    def usedBlocks(self):
-        dskPercent = self.cacheRRDValue("dskPercent", None)
-        if dskPercent is not None and dskPercent != "Unknown" and not isnan(dskPercent):
-            return self.getTotalBlocks() * dskPercent / 100.0
-
-        blocks = self.cacheRRDValue('usedBlocks', None)
-        if blocks is not None and not isnan(blocks):
-            return long(blocks)
-        
-        return None
-
-    def getTotalBlocks(self):
-
-        availBlocks = self.cacheRRDValue('availBlocks', None)
-        usedBlocks = self.usedBlocks()
-        if availBlocks is not None and usedBlocks is not None:
-            nonRootTotalBlocks = availBlocks + usedBlocks
-            return nonRootTotalBlocks
-
-        offset = getattr(self.primaryAq(), 'zFileSystemSizeOffset', 1.0)
-        return int(self.totalBlocks) * offset
-
     def usedBlocks(self):
         dskPercent = self.cacheRRDValue("dskPercent", None)
         if dskPercent is not None and dskPercent != "Unknown" and not isnan(dskPercent):
@@ -98,7 +65,7 @@ class FileSystem(schema.FileSystem):
                 return result.getObject()
             except Exception:
                 pass
-   
+
     def blockDevice(self):
         """Return the underlying HardDisk."""
         if not self.mount:

--- a/ZenPacks/zenoss/LinuxMonitor/modeler/plugins/zenoss/cmd/linux/df.py
+++ b/ZenPacks/zenoss/LinuxMonitor/modeler/plugins/zenoss/cmd/linux/df.py
@@ -18,7 +18,7 @@ class df(CommandPlugin):
     relname = "filesystems"
     modname = "ZenPacks.zenoss.LinuxMonitor.FileSystem"
     deviceProperties = \
-        CommandPlugin.deviceProperties + ('zFileSystemMapIgnoreNames',)
+        CommandPlugin.deviceProperties + ('zFileSystemMapIgnoreNames', 'zFileSystemSizeOffset')
 
     oses = ['Linux', 'Darwin', 'SunOS', 'AIX']
 
@@ -28,6 +28,7 @@ class df(CommandPlugin):
     def process(self, device, results, log):
         log.info('Collecting filesystems for device %s' % device.id)
         skipfsnames = getattr(device, 'zFileSystemMapIgnoreNames', None)
+        fs_offset = getattr(device, 'zFileSystemSizeOffset', 1.0)
         rm = self.relMap()
         rlines = results.split("\n")
         bline = ""
@@ -60,16 +61,17 @@ class df(CommandPlugin):
             if skipfsnames and re.search(skipfsnames, om.mount):
                 continue
 
-            if tblocks == "-":
-                om.totalBlocks = 0
-            else:
+            try:
+                total_blocks = long(tblocks)
+            except ValueError:
+                # total blocks may not be given
+                # so use (avail+used) divided by fs_offset (inverse of transform in getTotalBlocks()
                 try:
-                    om.totalBlocks = long(tblocks)
-                except ValueError:
-                    # Ignore this filesystem if what we thought was total
-                    # blocks isn't a number.
-                    continue
+                    total_blocks = (u + a) / fs_offset
+                except Exception:
+                    total_blocks = 0
 
+            om.totalBlocks = long(total_blocks)
             om.blockSize = 1024
             om.id = self.prepId(om.mount)
             om.title = om.mount


### PR DESCRIPTION
- Fixes ZPS-1312
- Remove getTotalBlocks() method override from FileSystem, which was
providing the total as (used + avail) perf metric instead of modeled
value
- Update df.py modeler plugin to use (avail + used) where total blocks
is not available in the output