### PR TITLE
Use FileSystem_NFS_Client template for all NFS

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -592,6 +592,10 @@ The following flavors of Linux are supported
 Changes
 -------
 
+2.2.3
+
+- Use FileSystem_NFS_Client template for all NFS mounts (including nfs4). (ZPS-1495)
+
 2.2.2
 
 - Fix query service overloading during Analytics ETL of Linux devices. (ZPS-1312)

--- a/ZenPacks/zenoss/LinuxMonitor/FileSystem.py
+++ b/ZenPacks/zenoss/LinuxMonitor/FileSystem.py
@@ -105,15 +105,18 @@ class FileSystem(schema.FileSystem):
         """
         old_templates = super(FileSystem, self).getRRDTemplates()
 
-        if self.type != 'nfs':
+        if self.type and not self.type.lower().startswith("nfs"):
             return old_templates
 
         new_templates = []
 
         for template in old_templates:
             if 'FileSystem' in template.id and 'FileSystem_NFS_Client' not in template.id:
-                new_templates.append(self.getRRDTemplateByName(
-                    template.id.replace('FileSystem', 'FileSystem_NFS_Client')))
+                nfs_template = self.getRRDTemplateByName(
+                    template.id.replace('FileSystem', 'FileSystem_NFS_Client'))
+
+                if nfs_template:
+                    new_templates.append(nfs_template)
             else:
                 new_templates.append(template)
 

--- a/ZenPacks/zenoss/LinuxMonitor/tests/test_FileSystem.py
+++ b/ZenPacks/zenoss/LinuxMonitor/tests/test_FileSystem.py
@@ -1,0 +1,78 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2017, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+from Products.ZenModel.RRDTemplate import manage_addRRDTemplate
+
+from .. import zenpacklib
+from ..FileSystem import FileSystem
+
+zenpacklib.enableTesting()
+
+
+class FileSystemTests(zenpacklib.TestCase):
+    def afterSetUp(self):
+        super(FileSystemTests, self).afterSetUp()
+
+        dc = self.dmd.Devices.createOrganizer("/Server/SSH/Linux")
+        dc.setZenProperty("zPythonClass", "ZenPacks.zenoss.LinuxMonitor.LinuxDevice")
+
+        self.device = dc.createInstance("linux-FileSystemTests")
+        self.device.setManageIp("127.0.0.1")
+        self.device.setPerformanceMonitor("localhost")
+
+    def test_getRRDTemplates(self):
+        boot_fs = FileSystem("boot")
+        boot_fs.mount = "/boot"
+        boot_fs.type = "ext4"
+        self.device.os.filesystems._setObject(boot_fs.id, boot_fs)
+        boot_fs = self.device.os.filesystems.boot
+
+        nfs_fs = FileSystem("nfs")
+        nfs_fs.mount = "/nfs"
+        nfs_fs.type = "nfs"
+        self.device.os.filesystems._setObject(nfs_fs.id, nfs_fs)
+        nfs_fs = self.device.os.filesystems.nfs
+
+        nfs4_fs = FileSystem("nfs4")
+        nfs4_fs.mount = "/nfs4"
+        nfs4_fs.type = "nfs4"
+        self.device.os.filesystems._setObject(nfs4_fs.id, nfs4_fs)
+        nfs4_fs = self.device.os.filesystems.nfs4
+
+        # No templates exist.
+        boot_templates = boot_fs.getRRDTemplates()
+        self.assertEqual(len(boot_templates), 0)
+
+        nfs_templates = nfs_fs.getRRDTemplates()
+        self.assertEqual(len(nfs_templates), 0)
+
+        # Only the FileSystem template exists.
+        manage_addRRDTemplate(self.dmd.Devices.rrdTemplates, "FileSystem")
+
+        boot_templates = boot_fs.getRRDTemplates()
+        self.assertEqual(len(boot_templates), 1)
+        self.assertEqual(boot_templates[0].id, "FileSystem")
+
+        nfs_templates = nfs_fs.getRRDTemplates()
+        self.assertEqual(len(nfs_templates), 0)
+
+        # FileSystem and FileSystem_NFS_Client templates exist.
+        manage_addRRDTemplate(self.dmd.Devices.rrdTemplates, "FileSystem_NFS_Client")
+
+        boot_templates = boot_fs.getRRDTemplates()
+        self.assertEqual(len(boot_templates), 1)
+        self.assertEqual(boot_templates[0].id, "FileSystem")
+
+        nfs_templates = nfs_fs.getRRDTemplates()
+        self.assertEqual(len(nfs_templates), 1)
+        self.assertEqual(nfs_templates[0].id, "FileSystem_NFS_Client")
+
+        nfs4_templates = nfs4_fs.getRRDTemplates()
+        self.assertEqual(len(nfs4_templates), 1)
+        self.assertEqual(nfs4_templates[0].id, "FileSystem_NFS_Client")


### PR DESCRIPTION
Previously the FileSystem.type had to be exactly "nfs". Now anything
that starts with "nfs" such as "nfs4" will also use the NFS template. I
also made the match case-insensitive.

Fixes ZPS-1495.