### PR TITLE
Wrap the df command in the FileSystem_NFS_Client template with a time…

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -595,6 +595,7 @@ Changes
 2.2.3
 
 - Use FileSystem_NFS_Client template for all NFS mounts (including nfs4). (ZPS-1495)
+- Prevent the creation of orphaned processes when an NFS mount becomes unavailable. (ZPS-1499)
 
 2.2.2
 

--- a/ZenPacks/zenoss/LinuxMonitor/zenpack.yaml
+++ b/ZenPacks/zenoss/LinuxMonitor/zenpack.yaml
@@ -1026,7 +1026,7 @@ device_classes:
                     disk:
                         type: COMMAND
                         usessh: true
-                        commandTemplate: "/usr/bin/env df -kP"
+                        commandTemplate: "export PATH=$PATH:/bin:/sbin:/usr/bin:/usr/sbin; if command -v timeout > /dev/null 2>&1; then timeout 30 /usr/bin/env df -kP; else /usr/bin/env df -kP; fi"
                         parser: ZenPacks.zenoss.LinuxMonitor.parsers.linux.df
                         component: "${here/id}"
                         eventClass: /Ignore
@@ -1047,7 +1047,7 @@ device_classes:
                     idisk:
                         type: COMMAND
                         usessh: true
-                        commandTemplate: "/usr/bin/env df -ikP"
+                        commandTemplate: "export PATH=$PATH:/bin:/sbin:/usr/bin:/usr/sbin; if command -v timeout > /dev/null 2>&1; then timeout 30 /usr/bin/env df -ikP; else /usr/bin/env df -ikP; fi"
                         parser: ZenPacks.zenoss.LinuxMonitor.parsers.linux.dfi
                         component: "${here/id}"
                         eventClass: /Ignore


### PR DESCRIPTION
…out command to prevent the creation of orphaned processes when an NFS mount becomes unavailable.

Fixes ZPS-1499