### PR TITLE
Fix inconsistencies with our data and df's output

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -597,6 +597,7 @@ Changes
 - Use FileSystem_NFS_Client template for all NFS mounts (including nfs4). (ZPS-1495)
 - Prevent the creation of orphaned processes when an NFS mount becomes unavailable. (ZPS-1499)
 - Fix "IndexError" when modeling tun interfaces. (ZPS-971)
+- Add percentUsed datapoint for filesystems. Use for UI and events. (ZPS-1545)
 
 2.2.2
 

--- a/ZenPacks/zenoss/LinuxMonitor/FileSystem.py
+++ b/ZenPacks/zenoss/LinuxMonitor/FileSystem.py
@@ -40,16 +40,42 @@ class FileSystem(schema.FileSystem):
     Instances of this class get stored in ZODB.
     """
 
-    def usedBlocks(self):
-        dskPercent = self.cacheRRDValue("dskPercent", None)
-        if dskPercent is not None and dskPercent != "Unknown" and not isnan(dskPercent):
-            return self.getTotalBlocks() * dskPercent / 100.0
+    def capacity(self):
+        return self.cacheRRDValue("disk_percentUsed")
 
-        blocks = self.cacheRRDValue('usedBlocks', None)
+    def getTotalBlocks(self):
+        """Return calculated total blocks.
+
+        Overridden here because zFileSystemSizeOffset is not applicable when
+        monitoring Linux devices via SSH because we have direct access to
+        "df" output which has already had any filesystem-specific
+        reservations considered.
+
+        """
+        return self.totalBlocks
+
+    def usedBlocks(self, default=None):
+        """Return number of used blocks.
+
+        Overridden here because we know the specific datapoint to check. This
+        spares the expense of looking for a variety of different datapoints in
+        the hopes that one is relevant.
+
+        """
+        blocks = self.cacheRRDValue('disk_usedBlocks', default)
         if blocks is not None and not isnan(blocks):
             return long(blocks)
 
-        return None
+    def availBlocks(self, default=None):
+        """Return number of available (free) blocks.
+
+        Overridden here because we know the disk_availBlocks datapoint will be
+        available.
+
+        """
+        blocks = self.cacheRRDValue('disk_availBlocks', default)
+        if blocks is not None and not isnan(blocks):
+            return long(blocks)
 
     def logicalVolume(self):
         """Return the underlying LogicalVolume."""
@@ -180,12 +206,6 @@ class FileSystem(schema.FileSystem):
             storagedevice = self.blockDevice()
 
         return storagedevice
-
-    def capacity(self):
-        utilization = super(FileSystem, self).capacity()
-        if isinstance(utilization, (int, float)):
-            return '{} %'.format(utilization)
-        return utilization
 
 
 @FunctionCache("LinuxFileSystem_getStorageServerPaths", default_timeout=60)

--- a/ZenPacks/zenoss/LinuxMonitor/migrate/UpdateFileSystemTransform.py
+++ b/ZenPacks/zenoss/LinuxMonitor/migrate/UpdateFileSystemTransform.py
@@ -1,0 +1,93 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2017, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+"""Update the /Perf/Filesystem transform to work with percentUsed datapoint."""
+
+import hashlib
+import logging
+
+from Products.ZenModel.ZenPack import ZenPackMigration
+from Products.ZenModel.migrate.Migrate import Version
+
+LOG = logging.getLogger("zen.migrate")
+
+NEW_TRANSFORM = """
+def transform():
+    if component and evt.eventKey:
+        try:
+            current = float(evt.current)
+            totalBytes = int(component.totalBytes())
+        except Exception:
+            return
+
+        if totalBytes < 1:
+            return
+
+        usedPercent, usedBytes, freeBytes = None, None, None
+
+        # SNMP (Platform)
+        if 'usedBlocks' in evt.eventKey:
+            usedBytes = int(current) * component.blockSize
+            usedPercent = (usedBytes / totalBytes) * 100.0
+            freeBytes = totalBytes - usedBytes
+
+        # Linux SSH (LinuxMonitor ZenPack)
+        elif 'percentUsed' in evt.eventKey:
+            usedPercent = current
+            usedBytes = totalBytes * (current * 0.01)
+            freeBytes = totalBytes - usedBytes
+
+        # Windows (Windows ZenPacks)
+        elif 'FreeMegabytes' in evt.eventKey:
+            freeBytes = int(current) * 1048576
+            usedBytes = totalBytes - freeBytes
+            usedPercent = (usedBytes / totalBytes) * 100.0
+
+        else:
+            return
+
+        # Make a nicer event summary.
+        from Products.ZenUtils.Utils import convToUnits
+        evt.summary = "disk space threshold: %3.1f%% used (%s free)" % (
+            usedPercent, convToUnits(freeBytes))
+        evt.message = evt.summary
+
+transform()
+""".strip()
+
+# MD5 hex digest of default transform in Zenoss 5.2.4.
+ORIGINAL_DIGEST = "18c01c20b29fef6f0b097a8bea443fa6"
+
+
+class UpdateFileSystemTransform(ZenPackMigration):
+    version = Version(2, 2, 3)
+
+    def migrate(self, pack):
+        eventclass = pack.dmd.Events.createOrganizer("Perf/Filesystem")
+        transform = eventclass.transform or ""
+
+        # No need to do anything if the transform is already updated.
+        if transform == NEW_TRANSFORM:
+            return
+
+        # Avoid overwriting custom transform, but offer the user enough
+        # information to update it on their own if they so choose.
+        if hashlib.md5(transform).hexdigest() != ORIGINAL_DIGEST:
+            LOG.warning(
+                "Not updating /Perf/Filesystem transform because it has been customized\n"
+                "\n"
+                "It would have been updated to the following otherwise.\n"
+                "\n"
+                "%s",
+                NEW_TRANSFORM)
+
+            return
+
+        LOG.info("Updating /Perf/Filesystem transform for percentUsed datapoint")
+        eventclass.transform = NEW_TRANSFORM

--- a/ZenPacks/zenoss/LinuxMonitor/modeler/plugins/zenoss/cmd/linux/df.py
+++ b/ZenPacks/zenoss/LinuxMonitor/modeler/plugins/zenoss/cmd/linux/df.py
@@ -20,7 +20,7 @@ class df(CommandPlugin):
     deviceProperties = CommandPlugin.deviceProperties + (
         'zFileSystemMapIgnoreNames',
         'zFileSystemMapIgnoreTypes',
-        'zFileSystemSizeOffset',)
+        )
 
     oses = ['Linux', 'Darwin', 'SunOS', 'AIX']
 
@@ -31,7 +31,6 @@ class df(CommandPlugin):
         log.info('Collecting filesystems for device %s' % device.id)
         skipfsnames = getattr(device, 'zFileSystemMapIgnoreNames', None)
         skipfstypes = getattr(device, 'zFileSystemMapIgnoreTypes', None) or []
-        fs_offset = getattr(device, 'zFileSystemSizeOffset', 1.0)
         rm = self.relMap()
         rlines = results.split("\n")
         bline = ""
@@ -88,14 +87,13 @@ class df(CommandPlugin):
             try:
                 total_blocks = long(tblocks)
             except ValueError:
-                # total blocks may not be given
-                # so use (avail+used) divided by fs_offset (inverse of transform in getTotalBlocks()
+                # Use avail + used if total is not available.
                 try:
-                    total_blocks = (u + a) / fs_offset
+                    total_blocks = long(u + a)
                 except Exception:
                     total_blocks = 0
 
-            om.totalBlocks = long(total_blocks)
+            om.totalBlocks = total_blocks
             om.blockSize = 1024
             om.id = self.prepId(om.mount)
             om.title = om.mount

--- a/ZenPacks/zenoss/LinuxMonitor/resources/device.js
+++ b/ZenPacks/zenoss/LinuxMonitor/resources/device.js
@@ -5,5 +5,13 @@ Ext.apply(Zenoss.render, {
         }
 
         return obj;
+    },
+
+    zenpacklib_ZenPacks_zenoss_LinuxMonitor_percentage: function(value) {
+        if (value === "Unknown" || value < 0) {
+            return _t("Unknown");
+        } else {
+            return value + "%";
+        }
     }
 });

--- a/ZenPacks/zenoss/LinuxMonitor/tests/test_modeler_df.py
+++ b/ZenPacks/zenoss/LinuxMonitor/tests/test_modeler_df.py
@@ -48,7 +48,6 @@ class FileSystemModelerTests(unittest.TestCase):
         self.plugin = df()
         self.device = DeviceProxy()
         self.device.id = "test-FileSystemModeler"
-        self.device.zFileSystemSizeOffset = 1.0
         self.device.zFileSystemMapIgnoreNames = ""
         self.device.zFileSystemMapIgnoreTypes = []
 

--- a/ZenPacks/zenoss/LinuxMonitor/zenpack.yaml
+++ b/ZenPacks/zenoss/LinuxMonitor/zenpack.yaml
@@ -441,6 +441,7 @@ classes:
                 api_backendtype: method
                 grid_display: true
                 details_display: true
+                renderer: Zenoss.render.zenpacklib_ZenPacks_zenoss_LinuxMonitor_percentage
                 order: 4.5
 
         dynamicview_views: [service_view]
@@ -926,13 +927,17 @@ device_classes:
                             usedBlocks:
                                 rrdmin: 0
                                 aliases:
-                                    fs__pct: "${here/getTotalBlocks},/,100,*"
-                                    fs_used__pct: "${here/getTotalBlocks},/,100,*"
                                     fs_used__bytes: "${here/blockSize},*"
                                     usedFilesystemSpace__bytes: "${here/blockSize},*"
 
                             availBlocks:
                                 rrdmin: 0
+
+                            percentUsed:
+                                rrdmin: 0
+                                aliases:
+                                    fs__pct: ""
+                                    fs_used__pct: ""
 
                     idisk:
                         type: COMMAND
@@ -967,10 +972,10 @@ device_classes:
                 thresholds:
                     "90 percent used":
                         type: MinMaxThreshold
-                        maxval: "here.getTotalBlocks() * 0.90"
+                        maxval: "90"
                         eventClass: /Perf/Filesystem
                         dsnames:
-                            - disk_usedBlocks
+                            - disk_percentUsed
 
                 graphs:
                     Utilization:
@@ -980,8 +985,7 @@ device_classes:
 
                         graphpoints:
                             Used:
-                                dpName: disk_usedBlocks
-                                rpn: "${here/getTotalBlocks},/,100,*"
+                                dpName: disk_percentUsed
                                 format: "%7.2lf%%"
 
                     Usage:
@@ -1036,13 +1040,17 @@ device_classes:
                             usedBlocks:
                                 rrdmin: 0
                                 aliases:
-                                    fs__pct: "${here/getTotalBlocks},/,100,*"
-                                    fs_used__pct: "${here/getTotalBlocks},/,100,*"
                                     fs_used__bytes: "${here/blockSize},*"
                                     usedFilesystemSpace__bytes: "${here/blockSize},*"
 
                             availBlocks:
                                 rrdmin: 0
+
+                            percentUsed:
+                                rrdmin: 0
+                                aliases:
+                                    fs__pct: ""
+                                    fs_used__pct: ""
 
                     idisk:
                         type: COMMAND
@@ -1082,8 +1090,7 @@ device_classes:
 
                         graphpoints:
                             Used:
-                                dpName: disk_usedBlocks
-                                rpn: "${here/getTotalBlocks},/,100,*"
+                                dpName: disk_percentUsed
                                 format: "%7.2lf%%"
 
                     Usage:


### PR DESCRIPTION
Attempting to calculate our own capacity value that matched the
"Capacity" column in Linux's df output turns out to be pretty much
impossible due to the various per-filesystem special reservations that
can make used + available != total.

This change takes what I hope is the simplest and best approach to
addressing this complication. We'll just collect and use the "Capacity"
column from df's output in all of the places where people expect that
value.

- Add percentUsed datapoint to filesystems
- Use percentUsed datapoint in Utilization graph
- Use percentUsed datapoint in default "90 percent used" threshold
- Use percentUsed in /Perf/Filesystem event transform

See ZPS-1545 for more detail on the problems that this change addresses.

Fixes ZPS-1545.