### PR TITLE
Guard all "df" commands against NFS timeout

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -595,6 +595,7 @@ Changes
 2.2.6
 
 - Fix issue with links between Linux and NetApp FileSystem components. (ZPS-1736)
+- Prevent the creation of orphaned processes when an NFS mount becomes unavailable. (ZPS-1499)
 
 2.2.5
 
@@ -608,7 +609,6 @@ Changes
 2.2.3
 
 - Use FileSystem_NFS_Client template for all NFS mounts (including nfs4). (ZPS-1495)
-- Prevent the creation of orphaned processes when an NFS mount becomes unavailable. (ZPS-1499)
 - Fix "IndexError" when modeling tun interfaces. (ZPS-971)
 - Add percentUsed datapoint for filesystems. Use for UI and events. (ZPS-1545)
 

--- a/ZenPacks/zenoss/LinuxMonitor/modeler/plugins/zenoss/cmd/linux/df.py
+++ b/ZenPacks/zenoss/LinuxMonitor/modeler/plugins/zenoss/cmd/linux/df.py
@@ -13,7 +13,7 @@ from Products.ZenUtils.IpUtil import getHostByName
 
 class df(CommandPlugin):
     maptype = "FilesystemMap"
-    command = '/bin/df -PTk'
+    command = 'export PATH=$PATH:/bin:/sbin:/usr/bin:/usr/sbin; if command -v timeout > /dev/null 2>&1; then timeout 30 /usr/bin/env df -PTk; else /usr/bin/env df -PTk; fi'
     compname = "os"
     relname = "filesystems"
     modname = "ZenPacks.zenoss.LinuxMonitor.FileSystem"

--- a/ZenPacks/zenoss/LinuxMonitor/tests/plugindata/df
+++ b/ZenPacks/zenoss/LinuxMonitor/tests/plugindata/df
@@ -1,4 +1,4 @@
-/bin/df -PTk
+export PATH=$PATH:/bin:/sbin:/usr/bin:/usr/sbin; if command -v timeout > /dev/null 2>&1; then timeout 30 /usr/bin/env df -PTk; else /usr/bin/env df -PTk; fi
 /dev/mapper/centos-root xfs         49746196 4035828  45710368       9% /
 devtmpfs                devtmpfs     1931008       0   1931008       0% /dev
 tmpfs                   tmpfs        1941228       4   1941224       1% /dev/shm

--- a/ZenPacks/zenoss/LinuxMonitor/zenpack.yaml
+++ b/ZenPacks/zenoss/LinuxMonitor/zenpack.yaml
@@ -917,7 +917,7 @@ device_classes:
                     disk:
                         type: COMMAND
                         usessh: true
-                        commandTemplate: "/usr/bin/env df -kP"
+                        commandTemplate: "/usr/bin/env df -klP"
                         parser: ZenPacks.zenoss.LinuxMonitor.parsers.linux.df
                         component: "${here/id}"
                         eventClass: /Ignore
@@ -942,7 +942,7 @@ device_classes:
                     idisk:
                         type: COMMAND
                         usessh: true
-                        commandTemplate: "/usr/bin/env df -ikP"
+                        commandTemplate: "/usr/bin/env df -iklP"
                         parser: ZenPacks.zenoss.LinuxMonitor.parsers.linux.dfi
                         component: "${here/id}"
                         eventClass: /Ignore


### PR DESCRIPTION
The previous fix for this issue (8840154) only wrapped the "df" command
within the FileSystem_NFS_Client monitoring template with a timeout.
This didn't help much because the same command was still being run from
the regular FileSystem monitoring template, and from the
zenoss.cmd.linux.df modeler plugin.

This update handles those two cases as well. This should prevent orphan
"df" command ever being left running on the target Linux server when it
is having timeouts reaching its NFS servers.

Furthermore the regular FileSystem monitoring template was updated to
use df's "-l" argument to limit it to only local filesystems. This means
we don't have to wrap it in a timeout at all, and it allows monitoring
of local filesystems to continue successfully even when NFS-mounted
filesystems timeout.

Tested on:

- RHEL 6
- CentOS 6
- CentOS 5
- Ubuntu 11
- SuSE 12
- Debian 8

Fixes ZPS-1499.