### PR TITLE
Set a timeout on local filesystem monitoring too

### DIFF
--- a/ZenPacks/zenoss/LinuxMonitor/zenpack.yaml
+++ b/ZenPacks/zenoss/LinuxMonitor/zenpack.yaml
@@ -917,7 +917,7 @@ device_classes:
                     disk:
                         type: COMMAND
                         usessh: true
-                        commandTemplate: "/usr/bin/env df -klP"
+                        commandTemplate: "export PATH=$$PATH:/bin:/sbin:/usr/bin:/usr/sbin; if command -v timeout > /dev/null 2>&1; then timeout 30 /usr/bin/env df -kP; else /usr/bin/env df -kP; fi"
                         parser: ZenPacks.zenoss.LinuxMonitor.parsers.linux.df
                         component: "${here/id}"
                         eventClass: /Ignore
@@ -942,7 +942,7 @@ device_classes:
                     idisk:
                         type: COMMAND
                         usessh: true
-                        commandTemplate: "/usr/bin/env df -iklP"
+                        commandTemplate: "export PATH=$$PATH:/bin:/sbin:/usr/bin:/usr/sbin; if command -v timeout > /dev/null 2>&1; then timeout 30 /usr/bin/env df -ikP; else /usr/bin/env df -ikP; fi"
                         parser: ZenPacks.zenoss.LinuxMonitor.parsers.linux.dfi
                         component: "${here/id}"
                         eventClass: /Ignore


### PR DESCRIPTION
It turns out that df's -l flag will also exclude some devicemapper
mounts. I tried using "df -kP -x nfs" to exclude NFS filesystems, but it
appears that df's -x and -t flags are only checked after the code that
results in a timeout, because "df -kP -x nfs" will also hang if there's
a hung NFS mount.

Fixes ZPS-1816.