### PR TITLE
Fix NoneType flare when clicking Storage Device

### DIFF
--- a/ZenPacks/zenoss/LinuxMonitor/resources/device.js
+++ b/ZenPacks/zenoss/LinuxMonitor/resources/device.js
@@ -1,7 +1,12 @@
 Ext.apply(Zenoss.render, {
     zenpacklib_ZenPacks_zenoss_LinuxMonitor_fileSystemStorageDevice: function(obj, metaData, record, rowIndex, colIndex) {
         if (typeof(obj) == "object") {
-            return Zenoss.render.zenpacklib_ZenPacks_zenoss_LinuxMonitor_entityLinkFromGrid(obj, metaData, record, rowIndex, colIndex);
+            var sameDevice = new RegExp("^" + this.uid).test(obj.uid);
+            if (sameDevice) {
+                return Zenoss.render.zenpacklib_ZenPacks_zenoss_LinuxMonitor_entityLinkFromGrid(obj, metaData, record, rowIndex, colIndex);
+            } else{
+                return Zenoss.render.link(obj);
+            }
         }
 
         return obj;


### PR DESCRIPTION
The custom renderer used for the filesystem "Storage Device" column
assumed that the storage device would be a component on the same device
such as a HardDisk or LogicalVolume component. In cases such as this
where the storage device is a NetApp FileSystem mounted via NFS, this
assumption breaks.

Updated the custom renderer to use a same-device link if the storage
device is on the same device as the filesystem, and to use a regular
link otherwise.

Fixes ZPS-1822.