### PR TITLE
Fix zencommand warnings monitoring NFS filesystems

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -605,6 +605,7 @@ Changes
 - Fix issue with links between Linux and NetApp FileSystem components. (ZPS-1736)
 - Prevent the creation of orphaned processes when an NFS mount becomes unavailable. (ZPS-1499)
 - Document support for RHEL 7, Ubuntu 16.04 LTS, and Debian 8. (ZPS-1820)
+- Fix spurious warnings in zencommand log when monitoring NFS mounted filesystems. (ZPS-1823)
 
 2.2.5
 

--- a/ZenPacks/zenoss/LinuxMonitor/zenpack.yaml
+++ b/ZenPacks/zenoss/LinuxMonitor/zenpack.yaml
@@ -917,7 +917,7 @@ device_classes:
                     disk:
                         type: COMMAND
                         usessh: true
-                        commandTemplate: "export PATH=$$PATH:/bin:/sbin:/usr/bin:/usr/sbin; if command -v timeout > /dev/null 2>&1; then timeout 30 /usr/bin/env df -kP; else /usr/bin/env df -kP; fi"
+                        commandTemplate: "/bin/sh -c 'export PATH=$$PATH:/bin:/sbin:/usr/bin:/usr/sbin; if command -v timeout > /dev/null 2>&1; then timeout 30 /usr/bin/env df -kP; else /usr/bin/env df -kP; fi'"
                         parser: ZenPacks.zenoss.LinuxMonitor.parsers.linux.df
                         component: "${here/id}"
                         eventClass: /Ignore
@@ -942,7 +942,7 @@ device_classes:
                     idisk:
                         type: COMMAND
                         usessh: true
-                        commandTemplate: "export PATH=$$PATH:/bin:/sbin:/usr/bin:/usr/sbin; if command -v timeout > /dev/null 2>&1; then timeout 30 /usr/bin/env df -ikP; else /usr/bin/env df -ikP; fi"
+                        commandTemplate: "/bin/sh -c 'export PATH=$$PATH:/bin:/sbin:/usr/bin:/usr/sbin; if command -v timeout > /dev/null 2>&1; then timeout 30 /usr/bin/env df -ikP; else /usr/bin/env df -ikP; fi'"
                         parser: ZenPacks.zenoss.LinuxMonitor.parsers.linux.dfi
                         component: "${here/id}"
                         eventClass: /Ignore
@@ -1030,7 +1030,7 @@ device_classes:
                     disk:
                         type: COMMAND
                         usessh: true
-                        commandTemplate: "export PATH=$$PATH:/bin:/sbin:/usr/bin:/usr/sbin; if command -v timeout > /dev/null 2>&1; then timeout 30 /usr/bin/env df -kP; else /usr/bin/env df -kP; fi"
+                        commandTemplate: "/bin/sh -c 'export PATH=$$PATH:/bin:/sbin:/usr/bin:/usr/sbin; if command -v timeout > /dev/null 2>&1; then timeout 30 /usr/bin/env df -kP; else /usr/bin/env df -kP; fi'"
                         parser: ZenPacks.zenoss.LinuxMonitor.parsers.linux.df
                         component: "${here/id}"
                         eventClass: /Ignore
@@ -1055,7 +1055,7 @@ device_classes:
                     idisk:
                         type: COMMAND
                         usessh: true
-                        commandTemplate: "export PATH=$$PATH:/bin:/sbin:/usr/bin:/usr/sbin; if command -v timeout > /dev/null 2>&1; then timeout 30 /usr/bin/env df -ikP; else /usr/bin/env df -ikP; fi"
+                        commandTemplate: "/bin/sh -c 'export PATH=$$PATH:/bin:/sbin:/usr/bin:/usr/sbin; if command -v timeout > /dev/null 2>&1; then timeout 30 /usr/bin/env df -ikP; else /usr/bin/env df -ikP; fi'"
                         parser: ZenPacks.zenoss.LinuxMonitor.parsers.linux.dfi
                         component: "${here/id}"
                         eventClass: /Ignore


### PR DESCRIPTION
Because the commandTemplate on these COMMAND datasources didn't begin
with a / (forward slash), zencommand would prefix the entire command
with the device's zCommandPath value, which is $ZENHOME/libexec by
default. This resulted in zencommand log messages like the following.

    WARNING zen.SshClient: <ip-address> channel 450 The command $ZENHOME/libexec/export PATH=$PATH:/bin:/sbin:/usr/bin:/usr/sbin; if command -v timeout > /dev/null 2>&1; then timeout 30 /usr/bin/env df -ikP; else /usr/bin/env df -ikP; fi returned stderr data (1) from the device: bash: /libexec/export: No such file or directory

It appears this didn't prevent monitoring from working because only the
export resulted in an error, and the other commands continued to
execute, and their output was parsed.

Fixes ZPS-1823.