### PR TITLE
Disable non-deterministic test_ten_devices test

### DIFF
--- a/ZenPacks/zenoss/LinuxMonitor/tests/test_NewDeviceType.py
+++ b/ZenPacks/zenoss/LinuxMonitor/tests/test_NewDeviceType.py
@@ -10,6 +10,7 @@
 """Test cases for NewDeviceType migration."""
 
 import datetime
+import unittest
 
 from Products.DataCollector.plugins.DataMaps import ObjectMap, RelationshipMap
 from Products.ZenModel.Device import Device
@@ -117,6 +118,7 @@ class migrateTests(zenpacklib.TestCase):
                 len(device.getDeviceComponents()),
                 30))
 
+    @unittest.skip("non-deterministic test that can fail on slow systems")
     def test_ten_devices(self):
         """Test migration of ten devices.
 


### PR DESCRIPTION
The nature of this test is that it fails when it takes too long. This
has caused at least one build to fail when it shouldn't have. Disabling
the test since it's non-deterministic.

Fixes ZPS-1827.