### PR TITLE
Use MemAvailable instead of MemFree for Used %

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -606,6 +606,7 @@ Changes
 - Prevent the creation of orphaned processes when an NFS mount becomes unavailable. (ZPS-1499)
 - Document support for RHEL 7, Ubuntu 16.04 LTS, and Debian 8. (ZPS-1820)
 - Fix spurious warnings in zencommand log when monitoring NFS mounted filesystems. (ZPS-1823)
+- Calculate memory utilization using "MemAvailable" when possible. (ZPS-1144)
 
 2.2.5
 

--- a/ZenPacks/zenoss/LinuxMonitor/parsers/linux/mem.py
+++ b/ZenPacks/zenoss/LinuxMonitor/parsers/linux/mem.py
@@ -26,7 +26,8 @@ class mem(CommandParser):
         data = [line.split(':', 1) for line in cmd.result.output.splitlines()]
 
         # For derivatives we always need to consider some keys.
-        desiredKeys = frozenset(datapointMap.keys() + ["MemFree", "MemTotal"])
+        desiredKeys = frozenset(
+            datapointMap.keys() + ["MemFree", "MemTotal", "MemAvailable"])
 
         # Extract values from data. Convert values to bytes.
         values = {}

--- a/ZenPacks/zenoss/LinuxMonitor/tests/parserdata/linux/leak.zenoss.loc/mem.py
+++ b/ZenPacks/zenoss/LinuxMonitor/tests/parserdata/linux/leak.zenoss.loc/mem.py
@@ -10,6 +10,8 @@
 
 {'foo': dict(MemTotal=2075652*1024,
            MemFree=720956*1024,
+           MemUsed=1387208704,
+           MemUsedPercent=65.2660465241765,
            Buffers=152440*1024,
            Cached=452440*1024,
            SwapTotal=2031608*1024,

--- a/ZenPacks/zenoss/LinuxMonitor/tests/parserdata/linux/linux-2.4/mem.py
+++ b/ZenPacks/zenoss/LinuxMonitor/tests/parserdata/linux/linux-2.4/mem.py
@@ -10,6 +10,8 @@
 
 {'foo': dict(MemTotal=4030996*1024,
            MemFree=154440*1024,
+           MemUsed=3969593344,
+           MemUsedPercent=96.16868883025435,
            Buffers=350872*1024,
            Cached=1885140*1024,
            SwapTotal=2097144*1024,

--- a/ZenPacks/zenoss/LinuxMonitor/tests/parserdata/linux/linux-4.4.0/mem
+++ b/ZenPacks/zenoss/LinuxMonitor/tests/parserdata/linux/linux-4.4.0/mem
@@ -1,0 +1,47 @@
+/bin/cat /proc/meminfo
+MemTotal:       65856916 kB
+MemFree:         2942080 kB
+MemAvailable:   39985356 kB
+Buffers:         1125568 kB
+Cached:         36026612 kB
+SwapCached:            0 kB
+Active:         32433264 kB
+Inactive:       28311276 kB
+Active(anon):   23884004 kB
+Inactive(anon):   604448 kB
+Active(file):    8549260 kB
+Inactive(file): 27706828 kB
+Unevictable:       19832 kB
+Mlocked:           19832 kB
+SwapTotal:             0 kB
+SwapFree:              0 kB
+Dirty:              2536 kB
+Writeback:             0 kB
+AnonPages:      23611896 kB
+Mapped:          1055996 kB
+Shmem:            889760 kB
+Slab:            1513380 kB
+SReclaimable:    1324116 kB
+SUnreclaim:       189264 kB
+KernelStack:       74912 kB
+PageTables:       137572 kB
+NFS_Unstable:          0 kB
+Bounce:                0 kB
+WritebackTmp:          0 kB
+CommitLimit:    32928456 kB
+Committed_AS:   61917388 kB
+VmallocTotal:   34359738367 kB
+VmallocUsed:           0 kB
+VmallocChunk:          0 kB
+HardwareCorrupted:     0 kB
+AnonHugePages:  19556352 kB
+CmaTotal:              0 kB
+CmaFree:               0 kB
+HugePages_Total:       0
+HugePages_Free:        0
+HugePages_Rsvd:        0
+HugePages_Surp:        0
+Hugepagesize:       2048 kB
+DirectMap4k:     2618200 kB
+DirectMap2M:    55982080 kB
+DirectMap1G:     9437184 kB

--- a/ZenPacks/zenoss/LinuxMonitor/tests/parserdata/linux/linux-4.4.0/mem.py
+++ b/ZenPacks/zenoss/LinuxMonitor/tests/parserdata/linux/linux-4.4.0/mem.py
@@ -1,0 +1,8 @@
+{'foo': {'Buffers': 1152581632,
+         'Cached': 36891250688,
+         'MemFree': 3012689920,
+         'MemTotal': 67437481984,
+         'MemUsed': 26492477440,
+         'MemUsedPercent': 39.28449974790802,
+         'SwapFree': 0,
+         'SwapTotal': 0}}


### PR DESCRIPTION
MemAvailable exists in newer kernels, and the difference between
MemTotal and MemAvailable is a more useful indicator of how much memory
is actively being used on a a system than the difference between
MemTotal and MemFree.

https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=34e431b0ae398fc54ea69ff85ec700722c9da773

The intention of 05269b2 was to do this, but the combination of the mem
parser's code, and the lack of a MemAvailable datapoint on the mem
datasource resulted in MemFree still being used. This change corrects
that by not requiring a MemAvailable datapoint to exist.

Fixes ZPS-1144.