### PR TITLE
Allow for restricted /bin/dmesg access in Debian9

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -188,7 +188,8 @@ allow the **zenmonitor** user to run the commands.
         Cmnd_Alias ZENOSS_SVC_CMDS = /bin/systemctl list-units *, \
             /bin/systemctl status *, /sbin/initctl list, /sbin/service --status-all, \
             /usr/sbin/dmidecode
-        zenmonitor ALL=(ALL) NOPASSWD: ZENOSS_LVM_CMDS, ZENOSS_SVC_CMDS
+        Cmnd_Alias ZENOSS_NET_CMDS = /bin/dmesg
+        zenmonitor ALL=(ALL) NOPASSWD: ZENOSS_LVM_CMDS, ZENOSS_SVC_CMDS, ZENOSS_NET_CMDS
 
    - Save, ensuring all paths for these commands are correct
 
@@ -599,6 +600,10 @@ Linux.
 
 Changes
 -------
+
+2.2.7
+
+- Allow for restricted dmesg access in Debian9. (ZPS-1933)
 
 2.2.6
 

--- a/ZenPacks/zenoss/LinuxMonitor/modeler/plugins/zenoss/cmd/linux/interfaces.py
+++ b/ZenPacks/zenoss/LinuxMonitor/modeler/plugins/zenoss/cmd/linux/interfaces.py
@@ -103,7 +103,7 @@ class interfaces(LinuxCommandPlugin):
                    echo "No ifconfig or ip utilities were found."; exit 127; \
                fi \
                && echo __COMMAND__ \
-               && /bin/dmesg \
+               && (/bin/dmesg || sudo -n /bin/dmesg || true) 2> /dev/null \
                && echo __COMMAND__ \
                && head /sys/class/net/*/speed 2>&1'
 


### PR DESCRIPTION
Fixes ZPS-1933

* Also is backward compatible with older systems.