### PR TITLE
Update links to storage providers for HardDisk components

### DIFF
--- a/ZenPacks/zenoss/LinuxMonitor/configure.zcml
+++ b/ZenPacks/zenoss/LinuxMonitor/configure.zcml
@@ -12,6 +12,12 @@
         factory=".FileSystem.FileSystemWrapper"
         />
 
+    <adapter
+        provides="Products.Zuul.catalog.interfaces.IIndexableWrapper"
+        for=".HardDisk.HardDisk"
+        factory=".HardDisk.HardDiskIndexableWrapper"
+        />
+
     <!-- Impact -->
     <configure zcml:condition="installed ZenPacks.zenoss.Impact">
         <include package="ZenPacks.zenoss.Impact" file="meta.zcml"/>

--- a/ZenPacks/zenoss/LinuxMonitor/zenpack.yaml
+++ b/ZenPacks/zenoss/LinuxMonitor/zenpack.yaml
@@ -361,6 +361,7 @@ classes:
                 - impacted_object
             impacted_by:
                 - device
+                - storage_disk_lun
 
     FileSystem:
         label: File System


### PR DESCRIPTION
Fixes ZPS-2905.

* Update HardDisk.storage_disk_lun method to find storage providers with 'has-target-wwn' ids
* Add HardDisk.disk_ids to searchKeywords
* Update impact for HardDisk components