### PR TITLE
Split Service templates per init System

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -120,11 +120,11 @@ OS Processes
     Severity
 
 OS Services
-    Attributes: Name, Description
+    Attributes: Name, Description, Init System
 
 .. Note::
-   On some Linux flavors some fields (Loaded Status, Processes,
-   Description) could be empty.
+   Prior to version 2.3.0, some columns (Loaded Status, Processes,
+   Description) may be empty. These columns are removed in version 2.3.0
 
 Set Linux Server Monitoring Credentials
 ---------------------------------------
@@ -291,23 +291,25 @@ Modeling and Monitoring OS Services
 The Linux OS services are modeled using the *zenoss.cmd.linux.os_service*
 modeler plugin. The following systems are supported:
 
-- RHEL 5 - systemV
-- RHEL 6 - upstart
-- RHEL 7 - systemd
-- CentOS 5 - systemV
-- CentOS 6 - upstart
-- CentOS 7 - systemd
-- Debian 8 - systemd
-- Debian 9 - systemd
-- Suse 12 - systemd
-- Ubuntu 12 - upstart
-- Ubuntu 14 - upstart
-- Ubuntu 15 - systemd
+- RHEL 5
+- RHEL 6
+- RHEL 7
+- CentOS 5
+- CentOS 6
+- CentOS 7
+- Debian 8
+- Debian 9
+- Suse 12
+- Ubuntu 12
+- Ubuntu 14
+- Ubuntu 15
 
 Version 2.3.0 supports monitoring of the status of **systemd**, **upstart**
-and **systemV** system services. The zProperties *zLinuxServicesModeled* and
-*zLinuxServicesNotModeled* restrict the services that are modeled and thereby
-monitored.
+and **systemV** system services. *OSService-SYSTEMD*, *OSService-UPSTART* and
+*OSService-SYSTEMD* monitoring templates are automatically bound to a service
+component based on the targets modeled init system value. The zProperties
+*zLinuxServicesModeled* and *zLinuxServicesNotModeled* restrict the services
+that are modeled and thereby monitored.
 
 +------------------------------+----------------------------------------------+
 | Name                         | Description                                  |
@@ -319,12 +321,12 @@ monitored.
 |                              | matches one or more services to not model    |
 +------------------------------+----------------------------------------------+
 
-Only *loaded* services are modeled. By default, both zProperties are empty. An
-empty value in ``zLinuxServiceModeled`` is treated as ``.*`` regex and models
-all loaded services. Both the zProperties can support multiple regex
-expressions when separated on new lines. The *OSService* monitoring template
-generates events on every collection cycle for a service that is down. The
-events are automatically cleared if the service is up again.
+Only *loaded* services are modeled. An empty value in ``zLinuxServiceModeled``
+is treated as ``.*`` regex and models all loaded services. Both the
+zProperties can support multiple regex expressions when separated on new lines.
+The *OSService* monitoring template generates events on every collection cycle
+for a service that is down. The events are automatically cleared if the service
+is up again.
 
 .. Note::
    ``zLinuxServicesNotModeled`` overrules ``zLinuxServicesModeled``. If a
@@ -383,7 +385,9 @@ Monitoring Templates
 -  VolumeGroup (in /Devices/Server/SSH/Linux)
 -  LogicalVolume (in /Devices/Server/SSH/Linux)
 -  OSProcess (in /Devices/Server/SSH/Linux)
--  OSService (in /Devices/Server/SSH/Linux)
+-  OSService-SYSTEMD (in /Devices/Server/SSH/Linux)
+-  OSService-UPSTART (in /Devices/Server/SSH/Linux)
+-  OSService-SYSTEMV (in /Devices/Server/SSH/Linux)
 -  ThinPool (in /Devices/Server/SSH/Linux)
 
 Monitoring Templates
@@ -651,7 +655,19 @@ OSProcess (in /Devices/Server/SSH/Linux)
    -  CPU Utilization
    -  Memory Usage
 
-OSService (in /Devices/Server/SSH/Linux)
+OSService-SYSTEMD (in /Devices/Server/SSH/Linux)
+
+-  Data Points
+
+   -  status
+
+OSService-UPSTART (in /Devices/Server/SSH/Linux)
+
+-  Data Points
+
+   -  status
+
+OSService-SYSTEMV (in /Devices/Server/SSH/Linux)
 
 -  Data Points
 

--- a/ZenPacks/zenoss/LinuxMonitor/LinuxService.py
+++ b/ZenPacks/zenoss/LinuxMonitor/LinuxService.py
@@ -22,4 +22,10 @@ class LinuxService(schema.LinuxService):
 
     """Model class for Linux OS Service."""
 
-    pass
+    def getRRDTemplates(self):
+        all_templates = super(LinuxService, self).getRRDTemplates()
+        used_templates = []
+        for template in all_templates:
+            if self.init_system in template.id:
+                used_templates.append(template)
+        return used_templates

--- a/ZenPacks/zenoss/LinuxMonitor/parsers/linux/service.py
+++ b/ZenPacks/zenoss/LinuxMonitor/parsers/linux/service.py
@@ -49,11 +49,11 @@ class service(CommandParser):
         if services[0] == 'SYSTEMV':
             if services[1] in SYSV_EXIT_CODE:
                 message = SYSV_EXIT_CODE.get(services[1])
-            elif services[1] in xrange(5, 99):
+            elif int(services[1]) in xrange(5, 99):
                 message = 'Reserved for future LSB use'
-            elif services[1] in xrange(100, 149):
+            elif int(services[1]) in xrange(100, 149):
                 message = 'Reserved for distribution use'
-            elif services[1] in xrange(150, 199):
+            elif int(services[1]) in xrange(150, 199):
                 message = 'Reserved for application use'
             else:
                 message = 'Reserved'

--- a/ZenPacks/zenoss/LinuxMonitor/tests/testOSServiceTemplates.py
+++ b/ZenPacks/zenoss/LinuxMonitor/tests/testOSServiceTemplates.py
@@ -1,0 +1,50 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2018, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+import logging
+import unittest
+
+from Products.ZenModel.RRDTemplate import manage_addRRDTemplate
+from ZenPacks.zenoss.LinuxMonitor.LinuxService import LinuxService
+
+LOG = logging.getLogger("zen.testcases")
+
+
+class ServiceTemplateTests(unittest.TestCase):
+    def test_serviceTemplates(self):
+        service = LinuxService("test_service")
+
+        # Add few templates to LinuxService component
+        manage_addRRDTemplate(service, "OSService-UPSTART")
+        manage_addRRDTemplate(service, "OSService-SYSTEMV")
+        manage_addRRDTemplate(service, "OSService-SYSTEMD")
+        manage_addRRDTemplate(service, "Extra-Template")
+        manage_addRRDTemplate(service, "Another-Extra-Template")
+
+        # SYSTEMD tests
+        service.init_system = 'SYSTEMD'
+        templates = service.getRRDTemplates()
+        self.assertEqual(len(templates), 1)
+        self.assertEqual(templates[0].id, 'OSService-SYSTEMD')
+
+        # UPSTART tests
+        service.init_system = 'UPSTART'
+        templates = service.getRRDTemplates()
+        self.assertEqual(len(templates), 1)
+        self.assertEqual(templates[0].id, 'OSService-UPSTART')
+
+        # SYSTEMV tests
+        service.init_system = 'SYSTEMV'
+        templates = service.getRRDTemplates()
+        self.assertEqual(len(templates), 1)
+        self.assertEqual(templates[0].id, 'OSService-SYSTEMV')
+
+        # OTHER-INIT tests
+        service.init_system = 'OTHER-INIT'
+        templates = service.getRRDTemplates()
+        self.assertEqual(len(templates), 0)

--- a/ZenPacks/zenoss/LinuxMonitor/tests/test_serviceParser.py
+++ b/ZenPacks/zenoss/LinuxMonitor/tests/test_serviceParser.py
@@ -158,9 +158,7 @@ class ServiceParserTests(BaseTestCase):
         service().processResults(self.cmd, result)
         self.assertEqual(result.events[0]['summary'], 'OS Service is up')
 
-    def disabled_test_SystemVEvents(self):
-        self.cmd.result.output = SYSTEMV_OUTPUT
-
+    def test_SystemVEvents(self):
         # Test Event is Up
         result = ParsedResults()
         self.cmd.component = 'test_service'
@@ -229,7 +227,7 @@ class ServiceParserTests(BaseTestCase):
         service().processResults(self.cmd, result)
         self.assertEqual(result.events[0]['summary'], 'OS Service is down')
         self.assertEqual(result.events[0]['message'], 'Exit status: ' +
-                         'Reserved for future distribution use')
+                         'Reserved for distribution use')
 
         # Test Event is Down with exit code 155
         result = ParsedResults()

--- a/ZenPacks/zenoss/LinuxMonitor/zenpack.yaml
+++ b/ZenPacks/zenoss/LinuxMonitor/zenpack.yaml
@@ -42,6 +42,15 @@ classes:
                 content_width: 250
                 order: 1.2
 
+            init_system:
+                label: Init System
+                order: 1.3
+                grid_display: False
+
+        monitoring_templates:
+            - OSService-SYSTEMD
+            - OSService-UPSTART
+            - OSService-SYSTEMV
         dynamicview_views: [service_view]
         dynamicview_weight: 30
         dynamicview_relations:
@@ -1334,25 +1343,75 @@ device_classes:
                                 dpName: ps_mem
                                 format: "%7.2lf%s"
 
-            OSService:
-                description: "Linux service monitoring via SSH."
+            OSService-SYSTEMD:
+                description: "Linux systemd init system monitoring via SSH."
                 targetPythonClass: ZenPacks.zenoss.LinuxMonitor.LinuxService
 
                 datasources:
                     service:
                         type: COMMAND
                         usessh: true
-                        # Check for systemd, upstart and systemv for services
+                        # Check for systemd for services
                         commandTemplate: >
                                            /bin/sh -c 'export PATH=$$PATH:/bin:/sbin:/usr/bin:/usr/sbin;
                                            if command -v systemctl > /dev/null 2>&1;
                                            then echo "SYSTEMD";
                                            sudo systemctl list-units -t service --all --no-page --no-legend |
-                                           sed "/not-found/d ; s/\s.*$$//" | xargs -n 1 sudo systemctl status -l -n 0 2>&1 || true;
-                                           elif command -v initctl >/dev/null 2>&1;
+                                           sed "/not-found/d ; s/\s.*$$//" | xargs -n 1 sudo systemctl status --no-pager -l -n 0 2>&1 || true;
+                                           else echo "UNKNOWN";
+                                           exit 127;
+                                           fi'
+                        parser: ZenPacks.zenoss.LinuxMonitor.parsers.linux.service
+                        component: "${here/id}"
+                        eventClass: /Status
+                        severity: Warning
+
+                        datapoints:
+                            status:
+                                rrdmin: 0
+                                aliases:
+                                    service_status: ""
+
+            OSService-UPSTART:
+                description: "Linux upstart init system monitoring via SSH."
+                targetPythonClass: ZenPacks.zenoss.LinuxMonitor.LinuxService
+
+                datasources:
+                    service:
+                        type: COMMAND
+                        usessh: true
+                        # Check for upstart for services
+                        commandTemplate: >
+                                           /bin/sh -c 'export PATH=$$PATH:/bin:/sbin:/usr/bin:/usr/sbin;
+                                           if command -v initctl >/dev/null 2>&1;
                                            then echo "UPSTART"; sudo initctl list 2>&1 || true;
-                                           elif command -v service >/dev/null 2>&1;
-                                           then echo "SYSTEMV"; sudo /etc/init.d/${here/id} status > /dev/null 2>&1; echo $$? || true;
+                                           else echo "UNKNOWN";
+                                           exit 127;
+                                           fi'
+                        parser: ZenPacks.zenoss.LinuxMonitor.parsers.linux.service
+                        component: "${here/id}"
+                        eventClass: /Status
+                        severity: Warning
+
+                        datapoints:
+                            status:
+                                rrdmin: 0
+                                aliases:
+                                    service_status: ""
+
+            OSService-SYSTEMV:
+                description: "Linux systemV monitoring via SSH."
+                targetPythonClass: ZenPacks.zenoss.LinuxMonitor.LinuxService
+
+                datasources:
+                    service:
+                        type: COMMAND
+                        usessh: true
+                        # Check for systemv for services
+                        commandTemplate: >
+                                           /bin/sh -c 'export PATH=$$PATH:/bin:/sbin:/usr/bin:/usr/sbin;
+                                           if command -v service >/dev/null 2>&1;
+                                           then echo "SYSTEMV"; sudo /etc/init.d/${here/title} status > /dev/null 2>&1; echo $$? || true;
                                            else echo "UNKNOWN";
                                            exit 127;
                                            fi'


### PR DESCRIPTION
Fixes ZPS-3442

After redesign of sysV systems, sysD monitoring breaks and places
zencommand in an infinite loop. To resolve this, we split monitoring
code to three different templates that bind to a linux device based
on their init_system which we set during modeling. Other things fixed:
- enabled unit tests for sysV
- fix additional sysV monitoring code