### PR TITLE
Update regex to match blank unitFileState service

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -329,8 +329,8 @@ modeled or monitored. In order to prevent a service from being modeled and
 monitored by Zenoss, the service will have to be stopped and disabled. One of
 those actions alone won’t be sufficient. Another way to prevent a service from
 modeling is to add it to the ``zLinuxServicesNotModeled`` zProperty. To also
-model disabled active services, the ``zLinuxModelAllActiveServices`` zProperty
-should be set to *True*.
+model active services of any UnitFileState (enabled, disabled, static, etc.),
+the ``zLinuxModelAllActiveServices`` zProperty should be set to *True*.
 
 **Upstart** devices monitor all enabled services managed by **upstart** and
 additionally also monitors **systemV** services that run in the current
@@ -348,8 +348,8 @@ menu of the service, displays which init system the service is managed by.
 | zLinuxServicesNotModeled     | Accepts regular expressions that             |
 |                              | matches one or more services to not model    |
 +------------------------------+----------------------------------------------+
-| zLinuxModelAllActiveServices | Boolean value used for systemD services that |
-|                              | models active services that are also disabled|
+| zLinuxModelAllActiveServices | Boolean value used for systemd services that |
+|                              | models active services of any UnitFileState  |
 +------------------------------+----------------------------------------------+
 
 ``zLinuxServiceModeled`` and ``zLinuxServiceNotModeled`` can support multiple
@@ -836,10 +836,11 @@ Changes
 - Fix 'no volume group' warning events during modeling. (ZPS-3475)
 - Add Idle, Interrupt, Soft Interrupt, Steal metrics on CPU Utilization graph. (ZPS-3547)
 - Enable better management of service events. (ZPS-3616)
-- Update SystemD service modeling. (ZPS-3545)
 - Fix OSService template binding errors in zenhub. (ZPS-3709)
 - Add systemV services to upstart devices. (ZPS-3478)
-- Added new zProperty and migration script to change the default value of zLinuxServicesModeled.
+- Update systemd services to not model oneshot or unmet conditions. (ZPS-3478, ZPS-3545)
+- Added new zProperty for systemd, zLinuxModelAllActiveServices. (ZPS-3478)
+- Added migration script to change the default value of zLinuxServicesModeled.
 - Tested with Zenoss Resource Manager 4.2.5 RPS 743, 5.3.3 and 6.1.2 and Service Impact 5.3.1.
 
 2.3.0

--- a/ZenPacks/zenoss/LinuxMonitor/__init__.py
+++ b/ZenPacks/zenoss/LinuxMonitor/__init__.py
@@ -38,8 +38,8 @@ class ZenPack(schema.ZenPack):
             'label': 'Regex expressions to ignore services from modeling'},
         'zLinuxModelAllActiveServices': {
             'type': 'boolean',
-            'description': 'Models disabled active SYSTEMD services but not oneshot or unmet conditions',
-            'label': 'Additionally models disabled active SYSTEMD services'},
+            'description': 'Models all active SYSTEMD services but not oneshot or unmet conditions',
+            'label': 'Models active SYSTEMD services of all unitFileStates'},
     }
 
     def install(self, app):

--- a/ZenPacks/zenoss/LinuxMonitor/modeler/plugins/zenoss/cmd/linux/os_service.py
+++ b/ZenPacks/zenoss/LinuxMonitor/modeler/plugins/zenoss/cmd/linux/os_service.py
@@ -276,7 +276,7 @@ RE_SYSTEMD_SERVICE_MODEL = re.compile(
                                 # active status
                                 'ActiveState=(?P<active_status>\w+)\n'
                                 # unit file state
-                                'UnitFileState=(?P<unit_file_state>\w+)\n'
+                                'UnitFileState=(?P<unit_file_state>[\w\-]*)\n'
                                 # condition
                                 'ConditionResult=(?P<condition_result>\w+)')
 RE_UPSTART_SERVICE = re.compile('(?P<title>[\w\-]+(\s\([\w\/-]+\))?)\s'    # service title

--- a/ZenPacks/zenoss/LinuxMonitor/tests/testOSServicePlugin.py
+++ b/ZenPacks/zenoss/LinuxMonitor/tests/testOSServicePlugin.py
@@ -72,7 +72,7 @@ Names=rtkit2-daemon.service
 Description=Another test case for service that should model
 LoadState=loaded
 ActiveState=active
-UnitFileState=enabled
+UnitFileState=enabled-runtime
 ConditionResult=yes
 __SPLIT__
 Title=temp-daemon.service
@@ -83,6 +83,16 @@ Description=Test case for service that is enabled but inactive, should model.
 LoadState=loaded
 ActiveState=inactive
 UnitFileState=enabled
+ConditionResult=yes
+__SPLIT__
+Title=blank-unitFileState.service
+Type=dbus
+MainPID=732
+Names=blank-unitFileState.service
+Description=Models only when zLinuxModelAllActiveServices is true.
+LoadState=loaded
+ActiveState=active
+UnitFileState=
 ConditionResult=yes"""
 
 UPSTART_OUTPUT = """UPSTART
@@ -300,7 +310,7 @@ class ServiceModelerTests(unittest.TestCase):
         # Test with default/blank value
         self.device.zLinuxModelAllActiveServices = True
         rm = self.plugin.process(self.device, SYSTEMD_OUTPUT, LOG)
-        self.assertEqual(len(rm[0].maps), 4)
+        self.assertEqual(len(rm[0].maps), 5)
         rm = self.plugin.process(self.device, UPSTART_OUTPUT, LOG)
         self.assertEqual(len(rm[0].maps), 8)
         rm = self.plugin.process(self.device, SYSTEMV_OUTPUT, LOG)


### PR DESCRIPTION
Update regex to capture UnitFileState when blank, full word (e.g. "enabled") and word with hyphen (e.g. "enabled-runtime"). Also updated unit tests to support regex update.