### PR TITLE
Prevent monitoring of potentially wrong services

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -830,6 +830,11 @@ Linux.
 
 Changes
 -------
+
+2.3.2
+
+- Guard against out of date sudoers configuration in service monitoring. (ZPS-4334)
+
 2.3.1
 
 - Fix CPU Busy metric on "CPU Utilization" graph. (ZPS-3531)

--- a/ZenPacks/zenoss/LinuxMonitor/LinuxService.py
+++ b/ZenPacks/zenoss/LinuxMonitor/LinuxService.py
@@ -16,18 +16,39 @@ All custom behavior for Linux OS Service is defined here.
 
 
 from . import schema
+from . import MODELER_VERSION_PROPERTY
+from . import OS_SERVICE_MODELER_VERSION
 
 
 class LinuxService(schema.LinuxService):
 
     """Model class for Linux OS Service."""
 
+    def getModelerVersion(self):
+        """Return version of modeler plugin that modeled this component, or 0 if unknown."""
+        if self.aqBaseHasAttr(MODELER_VERSION_PROPERTY):
+            try:
+                return int(getattr(self, MODELER_VERSION_PROPERTY))
+            except Exception:
+                return 0
+
+        return 0
+
     def getRRDTemplates(self):
+        """Return list of monitoring templates to use for this component."""
         all_templates = super(LinuxService, self).getRRDTemplates()
-        used_templates = []
+
+        # We don't know the init system, so we don't know how to monitor it.
         if not self.init_system:
-            return used_templates
+            return []
+
+        # We were modeled with too old of a modeler plugin. Monitoring would be unsafe.
+        if self.getModelerVersion() < OS_SERVICE_MODELER_VERSION:
+            return []
+
+        used_templates = []
         for template in all_templates:
             if self.init_system in template.id:
                 used_templates.append(template)
+
         return used_templates

--- a/ZenPacks/zenoss/LinuxMonitor/__init__.py
+++ b/ZenPacks/zenoss/LinuxMonitor/__init__.py
@@ -18,6 +18,10 @@ skinsDir = os.path.join(os.path.dirname(__file__), 'skins')
 if os.path.isdir(skinsDir):
     registerDirectory(skinsDir, globals())
 
+# Modeler plugin versioning to coordinate between modeling and monitoring.
+MODELER_VERSION_PROPERTY = "modeler_version"
+OS_SERVICE_MODELER_VERSION = 1
+
 # CFG is necessary when using zenpacklib.TestCase.
 CFG = zenpacklib.load_yaml()
 

--- a/ZenPacks/zenoss/LinuxMonitor/modeler/plugins/zenoss/cmd/linux/os_service.py
+++ b/ZenPacks/zenoss/LinuxMonitor/modeler/plugins/zenoss/cmd/linux/os_service.py
@@ -245,6 +245,7 @@ import re
 
 from Products.DataCollector.plugins.CollectorPlugin import LinuxCommandPlugin
 
+from ZenPacks.zenoss.LinuxMonitor import OS_SERVICE_MODELER_VERSION
 
 __doc__ = """os_service
 Collect linux services information using appropriate init service command.
@@ -453,6 +454,7 @@ class os_service(LinuxCommandPlugin):
                 om.title = title
                 om.init_system = init_system
                 om.description = groupdict.get('description', '').strip()
+                om.modeler_version = OS_SERVICE_MODELER_VERSION
                 rm.append(om)
             else:
                 log.debug("Unmapped in populateRelMap(): %s", line)

--- a/ZenPacks/zenoss/LinuxMonitor/tests/testOSServiceTemplates.py
+++ b/ZenPacks/zenoss/LinuxMonitor/tests/testOSServiceTemplates.py
@@ -10,6 +10,7 @@ import logging
 import unittest
 
 from Products.ZenModel.RRDTemplate import manage_addRRDTemplate
+from ZenPacks.zenoss.LinuxMonitor import OS_SERVICE_MODELER_VERSION
 from ZenPacks.zenoss.LinuxMonitor.LinuxService import LinuxService
 
 LOG = logging.getLogger("zen.testcases")
@@ -25,6 +26,20 @@ class ServiceTemplateTests(unittest.TestCase):
         manage_addRRDTemplate(service, "OSService-SYSTEMD")
         manage_addRRDTemplate(service, "Extra-Template")
         manage_addRRDTemplate(service, "Another-Extra-Template")
+
+        # Service modeled by "too old" of a modeler plugin (ZPS-4334).
+        service.modeler_version = None
+        service.init_system = 'SYSTEMD'
+        self.assertEqual(len(service.getRRDTemplates()), 0)
+        service.modeler_version = 0
+        self.assertEqual(len(service.getRRDTemplates()), 0)
+
+        # Set current modeler_version for remaining tests.
+        service.modeler_version = OS_SERVICE_MODELER_VERSION
+
+        # No init system modeled.
+        service.init_system = None
+        self.assertEqual(len(service.getRRDTemplates()), 0)
 
         # SYSTEMD tests
         service.init_system = 'SYSTEMD'

--- a/ZenPacks/zenoss/LinuxMonitor/zenpack.yaml
+++ b/ZenPacks/zenoss/LinuxMonitor/zenpack.yaml
@@ -51,6 +51,11 @@ classes:
                 order: 1.3
                 grid_display: False
 
+            modeler_version:
+                label: Modeler Plugin Version
+                type: int
+                grid_display: false
+
         monitoring_templates:
             - OSService-SYSTEMD
             - OSService-UPSTART


### PR DESCRIPTION
In LinuxMonitor 2.3.0 we began monitoring Linux services. There were
some problems in how we decided which services to model that resulted in
services that weren't supposed to be running (disabled in some way)
being modeled, and then being monitored. These services would flood the
system with events about services that were supposed to be down being
down.

We corrected this in LinuxMonitor 2.3.1, but in the process we added the
sudo execution of new commands to the cmd.linux.os_service modeler
plugin. This has had the result of making modeling fail for environments
where the sudo configuration was locked down to the previous set of sudo
commands. This modeling failure causes the erroneously-modeled "supposed
to be down" services to remain modeled, which results in monitoring
continuing, and the event spam for down services continuing.

One solution for this is for the customer to update their sudo
configurations to allow the new commands to be run according to the
documentation, but this isn't always an easy thing for customers to
change across a large environment.

This change attempts to address the problem by adding a
"modeler_version" property to LinuxService components. This allows us to
disable monitoring of services until such time as they're successfully
modeled using the new, fixed, cmd.linux.os_service modeler plugin.

The customer will have a modeling event on each Linux device where the
sudo configuration needs to be updated as a way of bringing light to the
correction that needs to be made.

Fixes ZPS-4334.