### PR TITLE
Allow df to work with or without sudo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -834,6 +834,7 @@ Changes
 2.3.2
 
 - Guard against out of date sudoers configuration in service monitoring. (ZPS-4334)
+- Allow filesystem modeling and monitoring to work with or without sudo access. (ZPS-4340)
 
 2.3.1
 

--- a/ZenPacks/zenoss/LinuxMonitor/tests/plugindata/df
+++ b/ZenPacks/zenoss/LinuxMonitor/tests/plugindata/df
@@ -1,4 +1,17 @@
-export PATH=$PATH:/bin:/sbin:/usr/bin:/usr/sbin; if command -v timeout > /dev/null 2>&1; then timeout 30 /usr/bin/env sudo df -PTk; else /usr/bin/env sudo df -PTk; fi
+export PATH=$PATH:/bin:/sbin:/usr/bin:/usr/sbin
+if command -v timeout >/dev/null 2>&1
+then
+    if ! timeout 30 /usr/bin/env sudo df -PTk 2>/dev/null
+    then
+        timeout 30 /usr/bin/env df -PTk
+    fi
+else
+    if ! /usr/bin/env sudo df -PTk 2>/dev/null
+    then
+        /usr/bin/env df -PTk
+    fi
+fi
+___HOST_OUTPUT___
 /dev/mapper/centos-root xfs         49746196 4035828  45710368       9% /
 devtmpfs                devtmpfs     1931008       0   1931008       0% /dev
 tmpfs                   tmpfs        1941228       4   1941224       1% /dev/shm

--- a/ZenPacks/zenoss/LinuxMonitor/zenpack.yaml
+++ b/ZenPacks/zenoss/LinuxMonitor/zenpack.yaml
@@ -1132,8 +1132,22 @@ device_classes:
                 datasources:
                     disk:
                         type: COMMAND
+                        commandTemplate: |-
+                            export PATH=$$PATH:/bin:/sbin:/usr/bin:/usr/sbin
+                            if command -v timeout >/dev/null 2>&1
+                            then
+                                if ! timeout 30 /usr/bin/env sudo df -kP 2>/dev/null
+                                then
+                                    timeout 30 /usr/bin/env df -kP
+                                fi
+                            else
+                                if ! /usr/bin/env sudo df -kP 2>/dev/null
+                                then
+                                    /usr/bin/env df -kP
+                                fi
+                            fi
+
                         usessh: true
-                        commandTemplate: "/bin/sh -c 'export PATH=$$PATH:/bin:/sbin:/usr/bin:/usr/sbin; if command -v timeout > /dev/null 2>&1; then timeout 30 /usr/bin/env sudo df -kP; else /usr/bin/env sudo df -kP; fi'"
                         parser: ZenPacks.zenoss.LinuxMonitor.parsers.linux.df
                         component: "${here/id}"
                         eventClass: /Ignore
@@ -1157,8 +1171,22 @@ device_classes:
 
                     idisk:
                         type: COMMAND
+                        commandTemplate: |-
+                            export PATH=$$PATH:/bin:/sbin:/usr/bin:/usr/sbin
+                            if command -v timeout >/dev/null 2>&1
+                            then
+                                if ! timeout 30 /usr/bin/env sudo df -ikP 2>/dev/null
+                                then
+                                    timeout 30 /usr/bin/env df -ikP
+                                fi
+                            else
+                                if ! /usr/bin/env sudo df -ikP 2>/dev/null
+                                then
+                                    /usr/bin/env df -ikP
+                                fi
+                            fi
+
                         usessh: true
-                        commandTemplate: "/bin/sh -c 'export PATH=$$PATH:/bin:/sbin:/usr/bin:/usr/sbin; if command -v timeout > /dev/null 2>&1; then timeout 30 /usr/bin/env sudo df -ikP; else /usr/bin/env sudo df -ikP; fi'"
                         parser: ZenPacks.zenoss.LinuxMonitor.parsers.linux.dfi
                         component: "${here/id}"
                         eventClass: /Ignore
@@ -1245,8 +1273,22 @@ device_classes:
                 datasources:
                     disk:
                         type: COMMAND
+                        commandTemplate: |-
+                            export PATH=$$PATH:/bin:/sbin:/usr/bin:/usr/sbin
+                            if command -v timeout >/dev/null 2>&1
+                            then
+                                if ! timeout 30 /usr/bin/env sudo df -kP 2>/dev/null
+                                then
+                                    timeout 30 /usr/bin/env df -kP
+                                fi
+                            else
+                                if ! /usr/bin/env sudo df -kP 2>/dev/null
+                                then
+                                    /usr/bin/env df -kP
+                                fi
+                            fi
+
                         usessh: true
-                        commandTemplate: "/bin/sh -c 'export PATH=$$PATH:/bin:/sbin:/usr/bin:/usr/sbin; if command -v timeout > /dev/null 2>&1; then timeout 30 /usr/bin/env sudo df -kP; else /usr/bin/env sudo df -kP; fi'"
                         parser: ZenPacks.zenoss.LinuxMonitor.parsers.linux.df
                         component: "${here/id}"
                         eventClass: /Ignore
@@ -1270,8 +1312,22 @@ device_classes:
 
                     idisk:
                         type: COMMAND
+                        commandTemplate: |-
+                            export PATH=$$PATH:/bin:/sbin:/usr/bin:/usr/sbin
+                            if command -v timeout >/dev/null 2>&1
+                            then
+                                if ! timeout 30 /usr/bin/env sudo df -ikP 2>/dev/null
+                                then
+                                    timeout 30 /usr/bin/env df -ikP
+                                fi
+                            else
+                                if ! /usr/bin/env sudo df -ikP 2>/dev/null
+                                then
+                                    /usr/bin/env df -ikP
+                                fi
+                            fi
+
                         usessh: true
-                        commandTemplate: "/bin/sh -c 'export PATH=$$PATH:/bin:/sbin:/usr/bin:/usr/sbin; if command -v timeout > /dev/null 2>&1; then timeout 30 /usr/bin/env sudo df -ikP; else /usr/bin/env sudo df -ikP; fi'"
                         parser: ZenPacks.zenoss.LinuxMonitor.parsers.linux.dfi
                         component: "${here/id}"
                         eventClass: /Ignore


### PR DESCRIPTION
We'll try first with sudo, and if that fails, we'll try without sudo.
This will allow for a seamless transition for users that are upgrading
from LinuxMonitor < 2.3.0 who have not updated their sudoers
configuration to allow df to be run via sudo.

Fixes ZPS-4340.