### PR TITLE
fix uncorroborated impact relationships

### DIFF
--- a/ZenPacks/zenoss/LinuxMonitor/HardDisk.py
+++ b/ZenPacks/zenoss/LinuxMonitor/HardDisk.py
@@ -57,7 +57,7 @@ class HardDisk(schema.HardDisk):
 
         results = itertools.chain.from_iterable(
             self.device().search(name, major_minor=self.major_minor)
-            for name in ('LogicalVolume', 'SnapshotVolume'))
+            for name in ('LogicalVolume', 'SnapshotVolume', 'ThinPool'))
 
         for result in results:
             try:
@@ -73,10 +73,6 @@ class HardDisk(schema.HardDisk):
         will return the proper object, or None.
 
         """
-        fs = self.filesystem()
-        if fs:
-            return fs
-
         pv = self.physicalVolume()
         if pv:
             return pv
@@ -84,6 +80,10 @@ class HardDisk(schema.HardDisk):
         lv = self.logicalVolume()
         if lv:
             return lv
+
+        fs = self.filesystem()
+        if fs:
+            return fs
 
     def storage_disk_lun(self):
         """Return a generator of the storage disks/virtual drives based on disk_ids."""


### PR DESCRIPTION
These changes fix the following uncorroborated impact relationships
reported by Impact's check-providers.py tool.

    INFO:zen.ProviderChecker:DSVRelationshipProvider(puffer/disk-data-z) provides uncorroborated impact: puffer/z
    INFO:zen.ProviderChecker:DSVRelationshipProvider(puffer/lv-data_z) provides uncorroborated impacted-by: puffer/disk-data-z

Fixes ZPS-5711.