### PR TITLE
fix disks being impacted by random objects.

### DIFF
--- a/ZenPacks/zenoss/LinuxMonitor/modeler/plugins/zenoss/cmd/linux/lvm.py
+++ b/ZenPacks/zenoss/LinuxMonitor/modeler/plugins/zenoss/cmd/linux/lvm.py
@@ -239,9 +239,9 @@ class lvm(CommandPlugin):
                         # 'scsi-SATA_INTEL_SSDSC2BB1PHWA616003QY120CGN',
                         # 'ata-INTEL_SSDSC2BB120G6K_PHWA616003QY120CGN'
                         # add the part right of the last '_'
-                        disk_id = id[id.rfind('_') + 1:].upper()
-                        if disk_id not in hd_om.disk_ids:
-                            hd_om.disk_ids.append(disk_id)
+                        serial = id.split('_')[-1]
+                        if len(serial) > 12 and serial not in hd_om.disk_ids:
+                            hd_om.disk_ids.append(parts[-1])
 
         maps = []
         maps.append(RelationshipMap(


### PR DESCRIPTION
When modeling "disk_ids" that can be used to correlate disks to their
underlying storage provider, we try to pick serial numbers out. However,
there was a particularly greedy case that looked at Ubuntu swap disks
like "disk-qa--ubuntu--12-swap_1" and picked off the last "1" as a
serial number. We then search for any components in the system that have
"1" as a keyword and say that they impact us. This is definitely not a
good thing.

This change attempts to keep the behavior as close as possible to what
was originally intended while avoiding overly-simple keywords by
expecting serial numbers to have over 12 characters. The test data we
have for this feature shows only serial numbers 18 or more characters.

Fixes ZPS-5792.