### PR TITLE
fix OpenStack-related unit test failure

### DIFF
--- a/ZenPacks/zenoss/LinuxMonitor/tests/test_dynamicview.py
+++ b/ZenPacks/zenoss/LinuxMonitor/tests/test_dynamicview.py
@@ -249,14 +249,26 @@ class DynamicViewTests(DynamicViewTestCase):
     # Expected impact relationships.
     expected_impacts = EXPECTED_IMPACTS
 
-    # Devices to create.
-    device_data = {
-        "linux1": {
-            "deviceClass": "/Server/SSH/Linux",
-            "zPythonClass": "ZenPacks.zenoss.LinuxMonitor.LinuxDevice",
-            "dataMaps": DATAMAPS,
+    def get_device_data(self):
+        """Return device_data dict for devices to be created for testing."""
+        self.setup_OpenStackInfrastructure()
+
+        return {
+            "linux1": {
+                "deviceClass": "/Server/SSH/Linux",
+                "zPythonClass": "ZenPacks.zenoss.LinuxMonitor.LinuxDevice",
+                "dataMaps": DATAMAPS,
+            }
         }
-    }
+
+    def setup_OpenStackInfrastructure(self):
+        try:
+            import ZenPacks.zenoss.OpenStackInfrastructure  # noqa
+        except ImportError:
+            pass
+        else:
+            # ZPS-5799: Workaround a bug in the OpenStackInfrastructure ZenPack.
+            self.dmd.Devices.createOrganizer("/OpenStack/Infrastructure")
 
     def test_impacts(self):
         self.check_impacts()


### PR DESCRIPTION
This change fixes a unit test failure that will occur when the
OpenStackInfrastructure ZenPack is installed. There's a bug in that
ZenPack that assumes there will always be a /OpenStack/Infrastucture
device class, but there isn't in the test sandbox.

Fixes ZPS-5799.