### PR TITLE
fix modeling traceback introduced in c24bbc0

### DIFF
--- a/ZenPacks/zenoss/LinuxMonitor/modeler/plugins/zenoss/cmd/linux/lvm.py
+++ b/ZenPacks/zenoss/LinuxMonitor/modeler/plugins/zenoss/cmd/linux/lvm.py
@@ -241,7 +241,7 @@ class lvm(CommandPlugin):
                         # add the part right of the last '_'
                         serial = id.split('_')[-1]
                         if len(serial) > 12 and serial not in hd_om.disk_ids:
-                            hd_om.disk_ids.append(parts[-1])
+                            hd_om.disk_ids.append(serial)
 
         maps = []
         maps.append(RelationshipMap(


### PR DESCRIPTION
Using an undefined variable can result in a traceback like the following
when modeling systems with LVM.

    2019-05-17 13:24:42,458 ERROR zen.ZenModeler: Traceback (most recent call last):
      File "/opt/zenoss/Products/DataCollector/zenmodeler.py", line 670, in processClient
        datamaps = plugin.process(device, results, self.log)
      File "/mnt/src/ZenPacks.zenoss.LinuxMonitor/ZenPacks/zenoss/LinuxMonitor/modeler/plugins/zenoss/cmd/linux/lvm.py", line 244, in process
        hd_om.disk_ids.append(parts[-1])
    NameError: global name 'parts' is not defined

Fixes ZPS-5815.