### PR TITLE
fix "NotFound: tp-*" traceback modeling thin pools

### DIFF
--- a/ZenPacks/zenoss/LinuxMonitor/modeler/plugins/zenoss/cmd/linux/lvm.py
+++ b/ZenPacks/zenoss/LinuxMonitor/modeler/plugins/zenoss/cmd/linux/lvm.py
@@ -296,6 +296,10 @@ class lvm(CommandPlugin):
                 objmaps=tp_vg_oms))
 
             for lv_om in lv_maps:
+                if lv_om.relname == "thinPools":
+                    # ZPS-5816: Ignoring snapshots of thin pools.
+                    continue
+
                 if lv_om.vgname == vg_om.title:
                     lv_sv_oms = []
                     for sv_om in sv_maps:


### PR DESCRIPTION
We have no snapshotVolumes relationship on thin pools, yet the
zenoss.cmd.linux.lvm modeler plugin was trying to set it. This resulted
in tracebacks like the following when modeling.

    2019-05-17 13:56:27,388 INFO zen.ZenModeler: plugins: zenoss.cmd.linux.lvm
    2019-05-17 13:56:27,388 INFO zen.ZenModeler: SNMP monitoring off for puffer
    2019-05-17 13:56:27,390 INFO zen.ZenModeler: No portscan plugins found for puffer
    2019-05-17 13:56:27,814 INFO zen.CmdClient: command client finished collection for puffer
    2019-05-17 13:56:28,015 ERROR zen.ZenModeler: : Traceback (most recent call last):
      File "/opt/zenoss/Products/ZenHub/PBDaemon.py", line 109, in inner
        return callable(*args, **kw)
      File "/opt/zenoss/Products/ZenHub/services/ModelerService.py", line 163, in remote_applyDataMaps
        if adm._applyDataMap(device, map, commit=False):
      File "/opt/zenoss/Products/DataCollector/ApplyDataMap/applydatamap.py", line 131, in applyDataMap
        datamap = _process_relationshipmap(datamap, device)
      File "/opt/zenoss/Products/DataCollector/ApplyDataMap/applydatamap.py", line 369, in _process_relationshipmap
        parent = _get_relmap_target(base_device, relmap)
      File "/opt/zenoss/Products/DataCollector/ApplyDataMap/applydatamap.py", line 307, in _get_relmap_target
        return device.getObjByPath(relmap.compname)
      File "/opt/zenoss/Products/ZenModel/ZenModelBase.py", line 635, in getObjByPath
        return getObjByPath(self, path)
      File "/opt/zenoss/Products/ZenUtils/Utils.py", line 258, in getObjByPath
        raise NotFound( name )
    NotFound: tp-data_develop

Fixes ZPS-5816.