### PR TITLE
fix UCS disk impact regression in c24bbc0

### DIFF
--- a/ZenPacks/zenoss/LinuxMonitor/modeler/plugins/zenoss/cmd/linux/lvm.py
+++ b/ZenPacks/zenoss/LinuxMonitor/modeler/plugins/zenoss/cmd/linux/lvm.py
@@ -222,7 +222,6 @@ class lvm(CommandPlugin):
                 if match:
                     hd_om.disk_ids = disk_by_id_map[match.group('disk_name')]
 
-
             if hasattr(hd_om, 'disk_ids'):
                 for id in hd_om.disk_ids:
                     if id.startswith('wwn-0x') and len(id) == 38:
@@ -240,7 +239,7 @@ class lvm(CommandPlugin):
                         # 'ata-INTEL_SSDSC2BB120G6K_PHWA616003QY120CGN'
                         # add the part right of the last '_'
                         serial = id.split('_')[-1]
-                        if len(serial) > 12 and serial not in hd_om.disk_ids:
+                        if len(serial) > 7 and serial not in hd_om.disk_ids:
                             hd_om.disk_ids.append(serial)
 
         maps = []


### PR DESCRIPTION
In commit c24bbc0 I changed the modeler plugin to require that serial
numbers in disk IDs must be longer than 12 characters. It turns out that
this was too long. A drive serial number of "9XG56VGD" was found. So I'm
lowering that limit to include serial numbers longer than 7 characters.

Fixes ZPS-5828.