### PR TITLE
Fixed LVM components representation on Smart View

### DIFF
--- a/ZenPacks/zenoss/LinuxMonitor/modeler/plugins/zenoss/cmd/linux/lvm.py
+++ b/ZenPacks/zenoss/LinuxMonitor/modeler/plugins/zenoss/cmd/linux/lvm.py
@@ -340,7 +340,7 @@ class lvm(CommandPlugin):
         pv_om.id = 'pv-{}'.format(self.prepId(columns['pv_name']))
         pv_om.format = columns['pv_fmt']
         pv_om.attributes = self.lvm_parser.pv_attributes(columns['pv_attr'])
-        pv_om.uuid = columns['pv_uuid']
+        pv_om.pv_uuid = columns['pv_uuid']
         pv_om.set_volumeGroup = 'vg-{}'.format(columns['vg_name']) if columns['vg_name'] else ''
         pv_om.relname = 'physicalVolumes'
         pv_om.modname = 'ZenPacks.zenoss.LinuxMonitor.PhysicalVolume'
@@ -352,7 +352,7 @@ class lvm(CommandPlugin):
         vg_om.title = columns['vg_name']
         vg_om.id = 'vg-{}'.format(self.prepId(columns['vg_name']))
         vg_om.attributes = self.lvm_parser.vg_attributes(columns['vg_attr'])
-        vg_om.uuid = columns['vg_uuid']
+        vg_om.vg_uuid = columns['vg_uuid']
         vg_om.relname = 'volumeGroups'
         vg_om.modname = 'ZenPacks.zenoss.LinuxMonitor.VolumeGroup'
         return vg_om
@@ -365,7 +365,7 @@ class lvm(CommandPlugin):
         lv_om.id = 'lv-{}'.format(self.prepId(columns['vg_name'])+'_'+self.prepId(columns['lv_name']))
         lv_om.attributes = self.lvm_parser.lv_attributes(columns['lv_attr'])
         lv_om.lvsize = int(columns['lv_size'])
-        lv_om.uuid = columns['lv_uuid']
+        lv_om.lv_uuid = columns['lv_uuid']
         if columns['origin']:
             lv_om.origin = columns['origin']
             lv_om.relname = 'snapshotVolumes'

--- a/ZenPacks/zenoss/LinuxMonitor/tests/plugindata/lvm.py
+++ b/ZenPacks/zenoss/LinuxMonitor/tests/plugindata/lvm.py
@@ -14,7 +14,7 @@
              'modname': 'ZenPacks.zenoss.LinuxMonitor.VolumeGroup',
              'relname': 'volumeGroups',
              'title': 'lvmserver',
-             'uuid': 'RRYHWp-twqJ-x89e-1WXs-iDFu-R2EE-5KPL4d'}, },
+             'vg_uuid': 'RRYHWp-twqJ-x89e-1WXs-iDFu-R2EE-5KPL4d'}, },
         {'disk-sda':
             {'disk_ids': ['ata-3.14159', 'scsi-3.14159'],
              'id': 'disk-sda',
@@ -32,7 +32,7 @@
              'relname': 'physicalVolumes',
              'set_volumeGroup': 'vg-qa-ubuntu-12',
              'title': '/dev/sda5',
-             'uuid': 'keTXxa-Jlrw-0FJS-b2ye-iP15-fgsF-KavDVv'}, },
+             'pv_uuid': 'keTXxa-Jlrw-0FJS-b2ye-iP15-fgsF-KavDVv'}, },
         {'lv-lvmserver_share':
             {'attributes': ['writeable', 'inherited', 'active', 'open'],
              'id': 'lv-lvmserver_share',
@@ -40,7 +40,7 @@
              'modname': 'ZenPacks.zenoss.LinuxMonitor.LogicalVolume',
              'relname': 'logicalVolumes',
              'title': 'share',
-             'uuid': 'SBIYpJ-Xgcr-0nlT-ModL-aqev-1L2T-rQgZUX',
+             'lv_uuid': 'SBIYpJ-Xgcr-0nlT-ModL-aqev-1L2T-rQgZUX',
              'vgname': 'lvmserver'}, },
         {'tp-lvmserver_pool':
             {'attributes': ['thin pool','writeable','inherited','active','open','thin'],
@@ -50,7 +50,7 @@
              'metadatasize': 4194304,
              'relname': 'thinPools',
              'title': 'pool',
-             'uuid': 'Je2mF8-V0q3-CXVX-6p21-eBAD-VMPt-pEOczH',
+             'lv_uuid': 'Je2mF8-V0q3-CXVX-6p21-eBAD-VMPt-pEOczH',
              'vgname': 'lvmserver'}, },
         {'lv-lvmserver_share-snapshot':
             {'attributes': ['snapshot', 'writeable', 'inherited', 'active'],
@@ -60,6 +60,6 @@
              'origin': 'share',
              'relname': 'snapshotVolumes',
              'title': 'share-snapshot',
-             'uuid': 'LnFf8w-BUSe-1JNo-9Y07-Colf-ztAX-N8ih65',
+             'lv_uuid': 'LnFf8w-BUSe-1JNo-9Y07-Colf-ztAX-N8ih65',
              'vgname': 'lvmserver'}, },
     ]}

--- a/ZenPacks/zenoss/LinuxMonitor/zenpack.yaml
+++ b/ZenPacks/zenoss/LinuxMonitor/zenpack.yaml
@@ -97,7 +97,8 @@ classes:
                 grid_display: False
                 type: lines
 
-            uuid:
+            pv_uuid:
+                label: UUID
                 grid_display: False
 
             harddisk_id:
@@ -154,7 +155,7 @@ classes:
                 grid_display: False
                 type: lines
 
-            uuid:
+            vg_uuid:
                 label: UUID
                 grid_display: False
 
@@ -191,7 +192,7 @@ classes:
                 grid_display: False
                 details_display: False
 
-            uuid:
+            lv_uuid:
                 grid_display: False
                 details_display: False
 
@@ -263,7 +264,7 @@ classes:
                 grid_display: False
                 details_display: False
 
-            uuid:
+            lv_uuid:
                 grid_display: False
                 details_display: False
 
@@ -491,7 +492,7 @@ classes:
                 grid_display: False
                 details_display: False
 
-            uuid:
+            lv_uuid:
                 grid_display: False
                 details_display: False
 


### PR DESCRIPTION
Fixes ZPS-6103.

Renamed components' UUID property to more specific to avoid conflict. 
Fixed existing unit tests.